### PR TITLE
Upgrades mongo driver and uuid format

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,4 @@ plugins-ide.sbt
 src_managed
 *.deb
 *.changes
+.bsp

--- a/README.md
+++ b/README.md
@@ -23,9 +23,9 @@ The library is published to the [Bintray](https://bintray.com/commercetools/mave
 
     resolvers += Resolver.bintrayRepo("commercetools", "maven")
     
-    libraryDependencies += "io.sphere" %% "sphere-util" % "0.12.1"
-    libraryDependencies += "io.sphere" %% "sphere-json" % "0.12.1"
-    libraryDependencies += "io.sphere" %% "sphere-mongo" % "0.12.1"
+    libraryDependencies += "io.sphere" %% "sphere-util" % "0.12.2"
+    libraryDependencies += "io.sphere" %% "sphere-json" % "0.12.2"
+    libraryDependencies += "io.sphere" %% "sphere-mongo" % "0.12.2"
 
 ## License
 

--- a/json/README.md
+++ b/json/README.md
@@ -31,7 +31,7 @@ Until the artifacts are released to Maven Central, please use our public repo:
 
     resolvers += Resolver.bintrayRepo("commercetools", "maven")
 
-    libraryDependencies += "io.sphere" %% "sphere-json" % "0.12.1"
+    libraryDependencies += "io.sphere" %% "sphere-json" % "0.12.2"
 
 ## Basic Usage
 

--- a/mongo/README.md
+++ b/mongo/README.md
@@ -8,4 +8,4 @@ Until the artifacts are released to Maven Central, please use our public repo:
 
     resolvers += Resolver.bintrayRepo("commercetools", "maven")
 
-    libraryDependencies += "io.sphere" %% "sphere-mongo" % "0.12.1"
+    libraryDependencies += "io.sphere" %% "sphere-mongo" % "0.12.2"

--- a/mongo/mongo-core/dependencies.sbt
+++ b/mongo/mongo-core/dependencies.sbt
@@ -1,3 +1,3 @@
 libraryDependencies ++= Seq(
-  "org.mongodb" % "mongodb-driver-core" % "3.12.8" // tracking http://mongodb.github.io/mongo-scala-driver/2.6/changelog/
+  "org.mongodb" % "mongodb-driver-core" % "4.2.2" // tracking http://mongodb.github.io/mongo-java-driver/
 )

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "0.12.2-SNAPSHOT"
+ThisBuild / version := "1.0.0-M1"


### PR DESCRIPTION
Can we release this as a snapshot release, so I can investigate if this fixes our current `UUID` issues?
Also I guess it must become a major release, as not fully backwards compatible. Roundtrips work but the encoded `DBObject` might look a bit different with the uuid being already in a binary format.

Due to deprecation of the default JAVA_LEGACY as uuid representation for BSON we have to manually do that otherwise the mongo db client might insert the correct uuid format (if configured), but functions like `equals`, `toJson` and `toString` will fail on `BasicDBObjects`.
