### PR TITLE
cats instances more discoverable

### DIFF
--- a/json/json-core/src/main/scala/io/sphere/json/FromJSON.scala
+++ b/json/json-core/src/main/scala/io/sphere/json/FromJSON.scala
@@ -26,7 +26,7 @@ trait FromJSON[@specialized A] extends Serializable {
   val fields: Set[String] = FromJSON.emptyFieldsSet
 }
 
-object FromJSON {
+object FromJSON extends FromJSONInstances {
 
   private[FromJSON] val emptyFieldsSet: Set[String] = Set.empty
 

--- a/json/json-core/src/main/scala/io/sphere/json/JSON.scala
+++ b/json/json-core/src/main/scala/io/sphere/json/JSON.scala
@@ -7,7 +7,7 @@ import scala.annotation.implicitNotFound
 @implicitNotFound("Could not find an instance of JSON for ${A}")
 trait JSON[A] extends FromJSON[A] with ToJSON[A]
 
-object JSON extends JSONLowPriorityImplicits {
+object JSON extends JSONInstances with JSONLowPriorityImplicits {
   @inline def apply[A](implicit instance: JSON[A]): JSON[A] = instance
 }
 

--- a/json/json-core/src/main/scala/io/sphere/json/ToJSON.scala
+++ b/json/json-core/src/main/scala/io/sphere/json/ToJSON.scala
@@ -18,7 +18,7 @@ trait ToJSON[@specialized A] extends Serializable {
 
 class JSONWriteException(msg: String) extends JSONException(msg)
 
-object ToJSON {
+object ToJSON extends ToJSONInstances {
 
   @inline def apply[A](implicit instance: ToJSON[A]): ToJSON[A] = instance
 

--- a/json/json-core/src/main/scala/io/sphere/json/catsinstances/package.scala
+++ b/json/json-core/src/main/scala/io/sphere/json/catsinstances/package.scala
@@ -5,13 +5,17 @@ import org.json4s.JValue
 
 /** Cats instances for [[JSON]], [[FromJSON]] and [[ToJSON]]
   */
-package object catsinstances extends JSONInstances
+package object catsinstances extends JSONInstances with FromJSONInstances with ToJSONInstances
 
 trait JSONInstances {
   implicit val catsInvariantForJSON: Invariant[JSON] = new JSONInvariant
+}
 
+trait FromJSONInstances {
   implicit val catsFunctorForFromJSON: Functor[FromJSON] = new FromJSONFunctor
+}
 
+trait ToJSONInstances {
   implicit val catsContravariantForToJSON: Contravariant[ToJSON] = new ToJSONContravariant
 }
 

--- a/mongo/mongo-core/src/main/scala/io/sphere/mongo/format/MongoFormat.scala
+++ b/mongo/mongo-core/src/main/scala/io/sphere/mongo/format/MongoFormat.scala
@@ -1,5 +1,6 @@
 package io.sphere.mongo.format
 
+import io.sphere.mongo.MongoFormatInstances
 import org.bson.BSONObject
 
 import scala.annotation.implicitNotFound
@@ -15,7 +16,7 @@ trait MongoFormat[@specialized A] extends Serializable {
   val fields: Set[String] = MongoFormat.emptyFieldsSet
 }
 
-object MongoFormat {
+object MongoFormat extends MongoFormatInstances {
 
   private[MongoFormat] val emptyFieldsSet: Set[String] = Set.empty
 


### PR DESCRIPTION
similar to what was done in cats, add the cats instances to the companion objects.
Those instances are better discoverable without additional import.
And the scala compilation is faster.