### PR TITLE
optimize Money

### DIFF
--- a/util/src/main/scala/Money.scala
+++ b/util/src/main/scala/Money.scala
@@ -280,7 +280,7 @@ object Money {
       "The scale of the given amount does not match the scale of the provided currency." +
         " - " + amount.scale + " <-> " + currency.getDefaultFractionDigits
     )
-    fromDecimalAmount(amount, currency)(BigDecimal.RoundingMode.HALF_EVEN)
+    fromDecimalAmount(amount, currency)(BigDecimal.RoundingMode.UNNECESSARY)
   }
 
   private final val bdOne: BigDecimal = BigDecimal(1)

--- a/util/src/main/scala/Money.scala
+++ b/util/src/main/scala/Money.scala
@@ -287,7 +287,7 @@ object Money {
   final val bdTen: BigDecimal = BigDecimal(10)
 
   private final val centPowerZeroFractionDigit = bdOne
-  private final val centPowerOneFractionDigit = bdTen.pow(1)
+  private final val centPowerOneFractionDigit = bdTen
   private final val centPowerTwoFractionDigit = bdTen.pow(2)
   private final val centPowerThreeFractionDigit = bdTen.pow(3)
   private final val centPowerFourFractionDigit = bdTen.pow(4)

--- a/util/src/main/scala/Money.scala
+++ b/util/src/main/scala/Money.scala
@@ -212,11 +212,11 @@ case class Money private (centAmount: Long, currency: Currency)
     val centAmountString = this.centAmount.toString
     val formattedString = new StringBuilder()
     val centAmountLength = centAmountString.length
-    val digits = this.fractionDigits
-    val missing = digits - centAmountLength
+    val decimals = this.fractionDigits
+    val missing = decimals - centAmountLength
     if (missing >= 0) {
       formattedString.append("0.")
-      for (_ <- 1 to (digits - centAmountLength))
+      for (_ <- 1 to missing)
         formattedString.append('0')
     }
 
@@ -224,7 +224,7 @@ case class Money private (centAmount: Long, currency: Currency)
     centAmountString.iterator.foreach { c =>
       formattedString.append(c)
       i += 1
-      if (centAmountLength - i == digits) formattedString.append(".")
+      if (centAmountLength - i == decimals) formattedString.append(".")
     }
     formattedString.result() + " " + this.currency.getCurrencyCode
   }

--- a/util/src/main/scala/Money.scala
+++ b/util/src/main/scala/Money.scala
@@ -83,31 +83,21 @@ object BaseMoney {
   * @param currency
   *   The currency of the amount.
   */
-case class Money private (amount: BigDecimal, currency: Currency)
+case class Money private (centAmount: Long, currency: Currency)
     extends BaseMoney
     with Ordered[Money] {
   import Money._
 
-  require(
-    amount.scale == currency.getDefaultFractionDigits,
-    "The scale of the given amount does not match the scale of the provided currency." +
-      " - " + amount.scale + " <-> " + currency.getDefaultFractionDigits
-  )
-
   private val centFactor: Double = 1 / pow(10, currency.getDefaultFractionDigits)
-
-  lazy val centAmount: Long = (amount / centFactor).toLong
-
   private val backwardsCompatibleRoundingModeForOperations = BigDecimal.RoundingMode.HALF_EVEN
 
   val `type`: String = TypeName
 
-  lazy val fractionDigits: Int = currency.getDefaultFractionDigits
+  override def fractionDigits: Int = currency.getDefaultFractionDigits
+  override lazy val amount: BigDecimal = BigDecimal(centAmount) * cachedCentFactor(fractionDigits)
 
-  def withCentAmount(centAmount: Long): Money = {
-    val newAmount = BigDecimal(centAmount) * centFactor
-    copy(amount = newAmount.setScale(currency.getDefaultFractionDigits))
-  }
+  def withCentAmount(centAmount: Long): Money =
+    copy(centAmount = centAmount)
 
   def toHighPrecisionMoney(fractionDigits: Int): HighPrecisionMoney =
     HighPrecisionMoney.fromMoney(this, fractionDigits)
@@ -200,7 +190,7 @@ case class Money private (amount: BigDecimal, currency: Currency)
     */
   def partition(ratios: Int*): Seq[Money] = {
     val total = ratios.sum
-    val amountInCents = (this.amount / centFactor).toBigInt
+    val amountInCents = BigInt(this.centAmount)
     val amounts = ratios.map(amountInCents * _ / total)
     var remainder = amounts.foldLeft(amountInCents)(_ - _)
     amounts.map { amount =>
@@ -215,11 +205,29 @@ case class Money private (amount: BigDecimal, currency: Currency)
 
   def compare(that: Money): Int = {
     BaseMoney.requireSameCurrency(this, that)
-    this.amount.compare(that.amount)
+    this.centAmount.compare(that.centAmount)
   }
 
-  override def toString: String =
-    this.amount.bigDecimal.toPlainString + " " + this.currency.getCurrencyCode
+  override def toString: String = {
+    val centAmountString = this.centAmount.toString
+    val formattedString = new StringBuilder()
+    val centAmountLength = centAmountString.length
+    val digits = this.fractionDigits
+    val missing = digits - centAmountLength
+    if (missing >= 0) {
+      formattedString.append("0.")
+      for (_ <- 1 to (digits - centAmountLength))
+        formattedString.append('0')
+    }
+
+    var i = 0
+    centAmountString.iterator.foreach { c =>
+      formattedString.append(c)
+      i += 1
+      if (centAmountLength - i == digits) formattedString.append(".")
+    }
+    formattedString.result() + " " + this.currency.getCurrencyCode
+  }
 
   def toString(nf: NumberFormat, locale: Locale): String = {
     require(nf.getCurrency eq this.currency)
@@ -253,17 +261,46 @@ object Money {
   def GBP(amount: BigDecimal): Money = decimalAmountWithCurrencyAndHalfEvenRounding(amount, "GBP")
   def JPY(amount: BigDecimal): Money = decimalAmountWithCurrencyAndHalfEvenRounding(amount, "JPY")
 
-  val CurrencyCodeField: String = "currencyCode"
-  val CentAmountField: String = "centAmount"
-  val FractionDigitsField: String = "fractionDigits"
-  val TypeName: String = "centPrecision"
+  final val CurrencyCodeField: String = "currencyCode"
+  final val CentAmountField: String = "centAmount"
+  final val FractionDigitsField: String = "fractionDigits"
+  final val TypeName: String = "centPrecision"
 
   def fromDecimalAmount(amount: BigDecimal, currency: Currency)(implicit
-      mode: RoundingMode): Money =
-    Money(amount.setScale(currency.getDefaultFractionDigits, mode), currency)
+      mode: RoundingMode): Money = {
+    val fractionDigits = currency.getDefaultFractionDigits
+    val centAmountBigDecimal = amount * cachedCentPower(fractionDigits)
+    val centAmount = centAmountBigDecimal.setScale(0, mode).longValue
+    Money(centAmount, currency)
+  }
 
-  val bdOne: BigDecimal = BigDecimal(1)
-  val bdTen: BigDecimal = BigDecimal(10)
+  def apply(amount: BigDecimal, currency: Currency): Money = {
+    require(
+      amount.scale == currency.getDefaultFractionDigits,
+      "The scale of the given amount does not match the scale of the provided currency." +
+        " - " + amount.scale + " <-> " + currency.getDefaultFractionDigits
+    )
+    fromDecimalAmount(amount, currency)(BigDecimal.RoundingMode.HALF_EVEN)
+  }
+
+  private final val bdOne: BigDecimal = BigDecimal(1)
+  final val bdTen: BigDecimal = BigDecimal(10)
+
+  private final val centPowerZeroFractionDigit = bdOne
+  private final val centPowerOneFractionDigit = bdTen.pow(1)
+  private final val centPowerTwoFractionDigit = bdTen.pow(2)
+  private final val centPowerThreeFractionDigit = bdTen.pow(3)
+  private final val centPowerFourFractionDigit = bdTen.pow(4)
+
+  private[util] def cachedCentPower(currencyFractionDigits: Int): BigDecimal =
+    currencyFractionDigits match {
+      case 0 => centPowerZeroFractionDigit
+      case 1 => centPowerOneFractionDigit
+      case 2 => centPowerTwoFractionDigit
+      case 3 => centPowerThreeFractionDigit
+      case 4 => centPowerFourFractionDigit
+      case other => bdTen.pow(other)
+    }
 
   private val centFactorZeroFractionDigit = bdOne / bdTen.pow(0)
   private val centFactorOneFractionDigit = bdOne / bdTen.pow(1)
@@ -281,13 +318,8 @@ object Money {
       case other => bdOne / bdTen.pow(other)
     }
 
-  def fromCentAmount(centAmount: Long, currency: Currency): Money = {
-    val currencyFractionDigits = currency.getDefaultFractionDigits
-    val centFactor = cachedCentFactor(currencyFractionDigits)
-    val amount = BigDecimal(centAmount) * centFactor
-
-    fromDecimalAmount(amount, currency)(BigDecimal.RoundingMode.UNNECESSARY)
-  }
+  def fromCentAmount(centAmount: Long, currency: Currency): Money =
+    new Money(centAmount, currency)
 
   private val cachedZeroEUR = fromCentAmount(0L, Currency.getInstance("EUR"))
   private val cachedZeroUSD = fromCentAmount(0L, Currency.getInstance("USD"))

--- a/util/src/test/scala/DomainObjectsGen.scala
+++ b/util/src/test/scala/DomainObjectsGen.scala
@@ -13,9 +13,7 @@ object DomainObjectsGen {
 
   val money: Gen[Money] = for {
     currency <- currency
-    amount <- Gen
-      .chooseNum[Int](Int.MinValue, Int.MaxValue)
-      .map(i => BigDecimal(i, currency.getDefaultFractionDigits))
+    amount <- Gen.chooseNum[Long](Long.MinValue, Long.MaxValue)
   } yield Money(amount, currency)
 
   val highPrecisionMoney: Gen[HighPrecisionMoney] = for {

--- a/util/src/test/scala/MoneySpec.scala
+++ b/util/src/test/scala/MoneySpec.scala
@@ -107,6 +107,10 @@ class MoneySpec extends AnyFunSpec with Matchers with ScalaCheckDrivenPropertyCh
 
     it("should provide convenient toString") {
       (1.00 EUR).toString must be("1.00 EUR")
+      (0.10 EUR).toString must be("0.10 EUR")
+      (0.01 EUR).toString must be("0.01 EUR")
+      (0.00 EUR).toString must be("0.00 EUR")
+      (94.5 EUR).toString must be("94.50 EUR")
     }
 
     it("should not fail on toString") {


### PR DESCRIPTION
Optimize `Money` so that serializing it does not need to compute any `BigDecimal`.
The `amount: BigDecimal` is computed lazily and is being used in all money operations.