### PR TITLE
[Feat] Extend limit of possible subclasses for json derivation

### DIFF
--- a/json/json-derivation/src/main/scala/io/sphere/json/generic/package.fmpp.scala
+++ b/json/json-derivation/src/main/scala/io/sphere/json/generic/package.fmpp.scala
@@ -406,21 +406,21 @@ package object generic extends Logging {
   def jsonTypeSwitch[T: ClassTag, A1 <: T: ClassTag: FromJSON: ToJSON](selectors: List[TypeSelector[_]]): JSON[T] with TypeSelectorContainer =
     jsonTypeSwitch[T, A1, A1](selectors)
 
-  <#list 3..84 as i>
+  <#list 3..126 as i>
   <#assign typeParams><#list 1..i-1 as j>A${j}<#if i-1 != j>,</#if></#list></#assign>
   <#assign implTypeParams><#list 1..i as j>A${j} <: T : ToJSON : ClassTag<#if i !=j>,</#if></#list></#assign>
   def toJsonTypeSwitch[T: ClassTag, ${implTypeParams}](selectors: List[TypeSelectorToJSON[_]]): ToJSON[T] with TypeSelectorToJSONContainer = toJsonTypeSwitch[T, ${typeParams}](typeSelectorToJSON[A${i}]() :: selectors)
   </#list>
 
-  <#list 3..84 as i>
+  <#list 3..126 as i>
   <#assign typeParams><#list 1..i-1 as j>A${j}<#if i-1 != j>,</#if></#list></#assign>
   <#assign implTypeParams><#list 1..i as j>A${j} <: T : FromJSON : ClassTag<#if i !=j>,</#if></#list></#assign>
   def fromJsonTypeSwitch[T: ClassTag, ${implTypeParams}](selectors: List[TypeSelectorFromJSON[_]]): FromJSON[T] with TypeSelectorFromJSONContainer = fromJsonTypeSwitch[T, ${typeParams}](typeSelectorFromJSON[A${i}]() :: selectors)
   </#list>
 
-  <#list 3..84 as i>
+  <#list 3..126 as i>
   <#assign typeParams><#list 1..i-1 as j>A${j}<#if i-1 != j>,</#if></#list></#assign>
-  <#assign implTypeParams><#list 1..i as j>A${j} <: T : FromJSON : ToJSON : ClassTag<#if i !=j>,</#if></#list></#assign>
+  <#assign implTypeParams><#list 1..i as j>A${j} <: T : JSON : ClassTag<#if i !=j>,</#if></#list></#assign>
   def jsonTypeSwitch[T: ClassTag, ${implTypeParams}](selectors: List[TypeSelector[_]]): JSON[T] with TypeSelectorContainer = jsonTypeSwitch[T, ${typeParams}](typeSelector[A${i}]() :: selectors)
   </#list>
 


### PR DESCRIPTION
This PR extends the limit of classes for the `deriveJSON` macro. 
When working on a recent feature the limit of 83 Subclasses was hit.

When increasing the number of 83 that was previously set the compiler complains: 

```
Platform restriction: a parameter list's length cannot exceed 254.
```

Some background:

```
def doSomething[T: Impl](t: T): Unit
```

Will be compiled down to the equivalent of this in Java:

```
public static <T> void doSomething(final T t, final Main.Impl<T> evidence$1) 
```
Thats why the compiler complained about the length of the parameter list when just raising the number. Currently we create methods like this

```
def toJsonTypeSwitch[T: ClassTag, A3: ToJSON : FromJSON: ClassTag] // repeated for currently up to 83 'A's always requiring multiple implicits 
```

I introduced a type alias to compose implicits. Using that only a single evidence parameter is produced, instead of two. I found it out via try and error, actually I do not know underlying mechanics.

```
  type JSONCodec[T] = ToJSON[T] with FromJSON[T]
```

With that the maximum subclasses could be extended to 126. I even tried to go further by introducing

```
  type ToJSONWithClassTag[T] = ToJSON[T] with ClassTag[T]
```

But that gave me the following error:

```
[error] /Users/cnolle/workspace/commercetools/sphere-scala-libs/json/json-derivation/src/test/scala/io/sphere/json/JSONSpec.scala:217:75: could not find implicit value for evidence parameter of type io.sphere.json.generic.ToJSONWithClassTag[io.sphere.json.JSONSpec.Bird] (No ClassTag available for io.sphere.json.JSONSpec.Bird)
[error]       implicit val animalToJSON = toJsonTypeSwitch[Animal, Bird, Dog, Cat](Nil)
```
For now I hope 126 is enough 🤞 

Related PRs: 
https://github.com/commercetools/sphere-scala-libs/pull/262
https://github.com/commercetools/sphere-scala-libs/pull/37