### PR TITLE
Remove BigDecimal from HighPrecisionMoney constructor, so it's not al…

### DIFF
--- a/json/json-core/src/main/scala/io/sphere/json/ToJSON.scala
+++ b/json/json-core/src/main/scala/io/sphere/json/ToJSON.scala
@@ -132,7 +132,7 @@ object ToJSON extends ToJSONInstances {
         JField(BaseMoney.TypeField, toJValue(m.`type`)) ::
           JField(CurrencyCodeField, toJValue(m.currency)) ::
           JField(CentAmountField, toJValue(m.centAmount)) ::
-          JField(PreciseAmountField, toJValue(m.preciseAmountAsLong)) ::
+          JField(PreciseAmountField, toJValue(m.preciseAmount)) ::
           JField(FractionDigitsField, toJValue(m.fractionDigits)) ::
           Nil
       )

--- a/mongo/mongo-core/src/main/scala/io/sphere/mongo/format/DefaultMongoFormats.scala
+++ b/mongo/mongo-core/src/main/scala/io/sphere/mongo/format/DefaultMongoFormats.scala
@@ -218,7 +218,7 @@ trait DefaultMongoFormats {
           .append(BaseMoney.TypeField, m.`type`)
           .append(CurrencyCodeField, currencyFormat.toMongoValue(m.currency))
           .append(CentAmountField, longFormat.toMongoValue(m.centAmount))
-          .append(PreciseAmountField, longFormat.toMongoValue(m.preciseAmountAsLong))
+          .append(PreciseAmountField, longFormat.toMongoValue(m.preciseAmount))
           .append(FractionDigitsField, m.fractionDigits)
       override def fromMongoValue(any: Any): HighPrecisionMoney = any match {
         case dbo: BSONObject =>

--- a/util/src/main/scala/Money.scala
+++ b/util/src/main/scala/Money.scala
@@ -587,15 +587,12 @@ object HighPrecisionMoney {
   def fromCentAmount(
       centAmount: Long,
       fractionDigits: Int,
-      currency: Currency): HighPrecisionMoney = {
-    val amount = BigDecimal(centAmount) * centFactor(currency)
-
+      currency: Currency): HighPrecisionMoney =
     HighPrecisionMoney(
       centToPreciseAmount(centAmount, fractionDigits, currency),
       fractionDigits,
       centAmount,
       currency)
-  }
 
   def zero(fractionDigits: Int, currency: Currency): HighPrecisionMoney =
     fromCentAmount(0L, fractionDigits, currency)

--- a/util/src/test/scala/HighPrecisionMoneySpec.scala
+++ b/util/src/test/scala/HighPrecisionMoneySpec.scala
@@ -25,15 +25,6 @@ class HighPrecisionMoneySpec extends AnyFunSpec with Matchers with ScalaCheckDri
       ("0.01".EUR) must equal("0.01".EUR)
     }
 
-    it("should not allow creation of high precision money without sufficient scale") {
-      val thrown = intercept[IllegalArgumentException] {
-        HighPrecisionMoney(amount = 1, fractionDigits = 2, centAmount = 1, Euro)
-      }
-
-      assert(
-        thrown.getMessage == "requirement failed: The scale of the given amount does not match the scale of the provided currency. - 0 <-> 2")
-    }
-
     it(
       "should not allow creation of high precision money with less fraction digits than the currency has") {
       val thrown = intercept[IllegalArgumentException] {
@@ -45,11 +36,11 @@ class HighPrecisionMoneySpec extends AnyFunSpec with Matchers with ScalaCheckDri
     }
 
     it("should convert precise amount to long value correctly") {
-      "0.0001".EUR_PRECISE(4).preciseAmountAsLong must equal(1)
+      "0.0001".EUR_PRECISE(4).preciseAmount must equal(1)
     }
 
     it("should reduce fraction digits as expected") {
-      "0.0001".EUR_PRECISE(4).withFractionDigits(2).preciseAmountAsLong must equal(0)
+      "0.0001".EUR_PRECISE(4).withFractionDigits(2).preciseAmount must equal(0)
     }
 
     it("should support the unary '-' operator.") {


### PR DESCRIPTION
…ways present, lowering memory footprint.

- I ran the overload tests with this change. With Money they had 0% failure rate at 1500 concurrent users. With the current HighPrecisionMoney it was around 50%. With this change it was around 25-30%. So it does improve things a bit, but the fromPreciseAmount constructor still contains BigDecimals, so that might be worth another round of optimizations. 