### PR TITLE
CUT-224: Added abort to deriveMongoFormat if subtrait is not sealed

### DIFF
--- a/mongo/mongo-derivation/src/main/scala/io/sphere/mongo/generic/MongoFormatMacros.scala
+++ b/mongo/mongo-derivation/src/main/scala/io/sphere/mongo/generic/MongoFormatMacros.scala
@@ -15,9 +15,16 @@ private[generic] object MongoFormatMacros {
     else if (s.isClass) {
       val cs = s.asClass
       if (cs.isCaseClass) Set(cs)
-      else if ((cs.isTrait || cs.isAbstract) && cs.isSealed)
-        cs.knownDirectSubclasses.flatMap(collectKnownSubtypes(c)(_))
-      else Set.empty
+      else if (cs.isTrait || cs.isAbstract) {
+        if (cs.isSealed) {
+          cs.knownDirectSubclasses.flatMap(collectKnownSubtypes(c)(_))
+        } else {
+          c.abort(
+            c.enclosingPosition,
+            s"Can only enumerate values of a sealed trait or class, failed on: '${cs.name}'"
+          )
+        }
+      } else Set.empty
     } else Set.empty
 
   def mongoFormatProductApply(c: blackbox.Context)(

--- a/mongo/mongo-derivation/src/test/scala/io/sphere/mongo/generic/DeriveMongoformatSpec.scala
+++ b/mongo/mongo-derivation/src/test/scala/io/sphere/mongo/generic/DeriveMongoformatSpec.scala
@@ -86,6 +86,15 @@ class DeriveMongoformatSpec extends AnyWordSpec with Matchers {
       val newUser = fromMongo[UserWithPicture](newDbo)
       newUser must be(user)
     }
+
+    "fail to derive if trait is not sealed" in {
+      // Sealed
+      "implicit val mongo: MongoFormat[SealedSub] = deriveMongoFormat[SealedSub]" must compile
+      // Not sealed
+      "implicit val mongo: MongoFormat[NotSealed] = deriveMongoFormat[NotSealed]" mustNot compile
+      // Sealed, but child is not sealed
+      "implicit val mongo: MongoFormat[SealedParent] = deriveMongoFormat[SealedParent]" mustNot compile
+    }
   }
 }
 
@@ -118,4 +127,14 @@ object DeriveMongoformatSpec {
   object UserWithPicture {
     implicit val mongo: MongoFormat[UserWithPicture] = mongoProduct(apply _)
   }
+
+  sealed trait SealedParent
+
+  sealed trait SealedSub extends SealedParent
+  case class Sub1(x: String) extends SealedSub
+  case class Sub2(y: Int) extends SealedSub
+
+  trait NotSealed extends SealedParent
+  case class Sub3(x: String) extends NotSealed
+  case class Sub4(y: Int) extends NotSealed
 }


### PR DESCRIPTION
If there is a subtrait that is not sealed, but the top level trait is sealed, the `deriveMongoFormat` compiles but generates data it can't deserialize. Added a compile-time warning for this.