### PR TITLE
Improve performance of `FromJSON` instances for `Enumerations`

### DIFF
--- a/benchmarks/src/main/scala/json/EnumFromJsonBenchmark.scala
+++ b/benchmarks/src/main/scala/json/EnumFromJsonBenchmark.scala
@@ -8,13 +8,13 @@ import org.openjdk.jmh.annotations._
 import java.util.concurrent.TimeUnit
 import scala.annotation.nowarn
 
-
 object FewCasesEnum extends Enumeration {
   val First, Middle, End = Value
 }
 
-object ManyCasesEnum extends Enumeration{
-  val First, A, B, C, D, E, F, G, H, I, J, K, L, Middle, N, O, P, Q, R, S, T, U, V, W, X, Y, Z, End = Value
+object ManyCasesEnum extends Enumeration {
+  val First, A, B, C, D, E, F, G, H, I, J, K, L, Middle, N, O, P, Q, R, S, T, U, V, W, X, Y, Z,
+      End = Value
 }
 
 @State(Scope.Benchmark)
@@ -26,7 +26,6 @@ object ManyCasesEnum extends Enumeration{
 class EnumFromJSONBenchmark {
   private val fromJSONForManyCases: FromJSON[ManyCasesEnum.Value] = fromJsonEnum(ManyCasesEnum)
   private val fromJSONForFewCases: FromJSON[FewCasesEnum.Value] = fromJsonEnum(FewCasesEnum)
-
 
   @Param(
     Array(
@@ -44,7 +43,6 @@ class EnumFromJSONBenchmark {
   @Benchmark
   final def enumWithManyCasesFromJson(): JValidation[ManyCasesEnum.Value] =
     fromJSONForManyCases.read(json)
-
 
   @Benchmark
   final def enumWithFewCasesFromJson(): JValidation[FewCasesEnum.Value] =

--- a/benchmarks/src/main/scala/json/EnumFromJsonBenchmark.scala
+++ b/benchmarks/src/main/scala/json/EnumFromJsonBenchmark.scala
@@ -1,0 +1,53 @@
+package json
+
+import io.sphere.json.generic.fromJsonEnum
+import io.sphere.json.{FromJSON, JValidation}
+import org.json4s.JsonAST.JString
+import org.openjdk.jmh.annotations._
+
+import java.util.concurrent.TimeUnit
+import scala.annotation.nowarn
+
+
+object FewCasesEnum extends Enumeration {
+  val First, Middle, End = Value
+}
+
+object ManyCasesEnum extends Enumeration{
+  val First, A, B, C, D, E, F, G, H, I, J, K, L, Middle, N, O, P, Q, R, S, T, U, V, W, X, Y, Z, End = Value
+}
+
+@State(Scope.Benchmark)
+@BenchmarkMode(Array(Mode.Throughput))
+@Warmup(iterations = 10, time = 1)
+@Measurement(iterations = 10, time = 1)
+@Fork(value = 1)
+@nowarn("msg=unused value of type")
+class EnumFromJSONBenchmark {
+  private val fromJSONForManyCases: FromJSON[ManyCasesEnum.Value] = fromJsonEnum(ManyCasesEnum)
+  private val fromJSONForFewCases: FromJSON[FewCasesEnum.Value] = fromJsonEnum(FewCasesEnum)
+
+
+  @Param(
+    Array(
+      "First",
+      "Middle",
+      "End"
+    ))
+  var rawValue: String = _
+  private var json: JString = _
+
+  @Setup
+  final def setupJson(): Unit =
+    json = JString(rawValue)
+
+  @Benchmark
+  final def enumWithManyCasesFromJson(): JValidation[ManyCasesEnum.Value] =
+    fromJSONForManyCases.read(json)
+
+
+  @Benchmark
+  final def enumWithFewCasesFromJson(): JValidation[FewCasesEnum.Value] =
+    fromJSONForFewCases.read(json)
+
+}

--- a/json/json-derivation/src/main/scala/io/sphere/json/generic/package.fmpp.scala
+++ b/json/json-derivation/src/main/scala/io/sphere/json/generic/package.fmpp.scala
@@ -49,9 +49,9 @@ package object generic extends Logging {
   def fromJsonEnum(e: Enumeration): FromJSON[e.Value] = {
     // We're using an AnyRefMap for performance, it's not for mutability.
     val validRepresentations = AnyRefMap(
-      e.values.toList.map { value =>
+      e.values.iterator.map { value =>
         value.toString -> value.validNel[JSONError]
-      }:_*
+      }.toSeq:_*
     )
 
     val allowedValues = e.values.mkString("'", "','", "'")

--- a/json/json-derivation/src/main/scala/io/sphere/json/generic/package.fmpp.scala
+++ b/json/json-derivation/src/main/scala/io/sphere/json/generic/package.fmpp.scala
@@ -48,11 +48,11 @@ package object generic extends Logging {
     * representations of the enumeration values. */
   def fromJsonEnum(e: Enumeration): FromJSON[e.Value] = {
     // We're using an AnyRefMap for performance, it's not for mutability.
-    val validRepresentations = AnyRefMap.from {
+    val validRepresentations = AnyRefMap(
       e.values.toList.map { value =>
         value.toString -> value.validNel[JSONError]
-      }
-    }
+      }:_*
+    )
 
     val allowedValues = e.values.mkString("'", "','", "'")
 

--- a/json/json-derivation/src/main/scala/io/sphere/json/generic/package.fmpp.scala
+++ b/json/json-derivation/src/main/scala/io/sphere/json/generic/package.fmpp.scala
@@ -4,9 +4,9 @@ package io.sphere.json
 import cats.data.Validated.Valid
 import cats.data.ValidatedNel
 import cats.syntax.apply._
-import cats.syntax.option._
-
+import cats.syntax.validated._
 import scala.annotation.meta.getter
+import scala.collection.mutable.AnyRefMap
 import scala.collection.mutable.ListBuffer
 import scala.language.experimental.macros
 import scala.reflect.{ClassTag, classTag}
@@ -46,12 +46,23 @@ package object generic extends Logging {
 
   /** Creates a FromJSON instance for an Enumeration type that encodes the `toString`
     * representations of the enumeration values. */
-  def fromJsonEnum(e: Enumeration): FromJSON[e.Value] = new FromJSON[e.Value] {
-    def read(jval: JValue): ValidatedNel[JSONError, e.Value] = jval match {
-      case JString(s) => e.values.find(_.toString == s).toValidNel(
-        JSONParseError("Invalid enum value: '%s'. Expected one of: %s".format(s, e.values.mkString("'", "','", "'")))
-      )
-      case _ => jsonParseError("JSON String expected.")
+  def fromJsonEnum(e: Enumeration): FromJSON[e.Value] = {
+    // We're using an AnyRefMap for performance, it's not for mutability.
+    val validRepresentations = AnyRefMap.from {
+      e.values.toList.map { value =>
+        value.toString -> value.validNel[JSONError]
+      }
+    }
+
+    val allowedValues = e.values.mkString("'", "','", "'")
+
+    new FromJSON[e.Value] {
+      override def read(json: JValue): JValidation[e.Value] =
+        json match {
+          case JString(string) =>
+            validRepresentations.getOrElse(string, jsonParseError("Invalid enum value: '%s'. Expected one of: %s".format(string, allowedValues)))
+          case _ => jsonParseError("JSON String expected.")
+        }
     }
   }
 


### PR DESCRIPTION
In our project we're making heavy use of sphere-json, and we also have some rather large `Enumeration`s to model things like country codes (more than 250 cases).

When investigating some recent performance problems, we saw that deserialization of enums took up almost 20% of the time, which made us look into the implementation of the `FromJson` for `Enumeration`s and it turns out that the current implementation can become rather slow, especially for large enums.

Consequently, this change replaces the earlier implemetation with a map-based one.

# Performance comparison
## Approach
We did some comparitive benchmarks with variations along the following dimensions:
- size of the enum
   - large (~ 30 cases, smaller than the aforementioned use-case for country codes, which would be even more extreme)
   - small (3 cases)
- concrete raw String representation
   - "First" (the first value in the enum's value set)
   - "Middle" (a value in the middle of the enum's value set
   - "End" (the last value in the enum's value set)
## Results

On this branch:
```
[info] Benchmark                                        (rawValue)   Mode  Cnt          Score         Error  Units
[info] EnumFromJSONBenchmark.enumWithFewCasesFromJson        First  thrpt   10  114787869,055 ±  494183,238  ops/s
[info] EnumFromJSONBenchmark.enumWithFewCasesFromJson       Middle  thrpt   10  112786202,668 ±  507311,349  ops/s
[info] EnumFromJSONBenchmark.enumWithFewCasesFromJson          End  thrpt   10  117364460,023 ±  402937,784  ops/s
[info] EnumFromJSONBenchmark.enumWithManyCasesFromJson       First  thrpt   10  111717733,553 ± 1571494,154  ops/s
[info] EnumFromJSONBenchmark.enumWithManyCasesFromJson      Middle  thrpt   10  111276311,730 ±  886313,866  ops/s
[info] EnumFromJSONBenchmark.enumWithManyCasesFromJson         End  thrpt   10  115789681,737 ±  580377,173  ops/s
```

On the current main branch (original find-based implementation):
```
[info] Benchmark                                        (rawValue)   Mode  Cnt         Score         Error  Units
[info] EnumFromJSONBenchmark.enumWithFewCasesFromJson        First  thrpt   10  38743522,827 ±  295124,825  ops/s
[info] EnumFromJSONBenchmark.enumWithFewCasesFromJson       Middle  thrpt   10  22857016,768 ± 1308431,238  ops/s
[info] EnumFromJSONBenchmark.enumWithFewCasesFromJson          End  thrpt   10  18582060,837 ±   96683,104  ops/s
[info] EnumFromJSONBenchmark.enumWithManyCasesFromJson       First  thrpt   10  38845183,295 ±  383537,793  ops/s
[info] EnumFromJSONBenchmark.enumWithManyCasesFromJson      Middle  thrpt   10   4110176,695 ±   95060,527  ops/s
[info] EnumFromJSONBenchmark.enumWithManyCasesFromJson         End  thrpt   10   1902526,501 ±   25851,315  ops/s
```

As we can see the solution proposed in this branch outperforms the existing one for all the examined cases, for the extreme case (last value of a large enum) by a factor of ~ 60. This is more or less what one would expect from a theoretical perspective when comparing `O(n)` and `O(1)`. 


## Other Considerations
We are paying a slight up-front overhead and memory penalty to allocate the map on construction, but on the other hand, this allows us to also memoize the `Valid` results for successful lookup, which should additionally reduce GC pressure at run time.