### PR TITLE
Add eventstore team as codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,3 +1,3 @@
 # why this file: to pick reviewers for a pull request automatically
 # doc on https://help.github.com/articles/about-codeowners/
-*       @yanns
+*       @yanns @commercetools/event-store-team


### PR DESCRIPTION
Since these libraries are quite relevant to our persistence layer, this change adds team "eventstore" as code-owners, since this is part of their core domain.