### PR TITLE
Throw Exception on Money Overflow

### DIFF
--- a/util/src/main/scala/Money.scala
+++ b/util/src/main/scala/Money.scala
@@ -16,8 +16,7 @@ import ValidatedFlatMapFeature._
 import io.sphere.util.BaseMoney.bigDecimalToMoneyLong
 import io.sphere.util.Money.ImplicitsDecimal.MoneyNotation
 
-class MoneyOverflowException
-    extends ArithmeticException("A Money operation resulted in an overflow.")
+class MoneyOverflowException extends RuntimeException("A Money operation resulted in an overflow.")
 
 sealed trait BaseMoney {
   def `type`: String

--- a/util/src/main/scala/Money.scala
+++ b/util/src/main/scala/Money.scala
@@ -16,9 +16,9 @@ import ValidatedFlatMapFeature._
 import io.sphere.util.BaseMoney.bigDecimalToMoneyLong
 import io.sphere.util.Money.ImplicitsDecimal.MoneyNotation
 
-class MoneyOverflowException(number: BigDecimal)
+class MoneyOverflowException(amount: BigDecimal)
     extends RuntimeException(
-      s"Money operation resulted in an overflow. $number is too big or small.")
+      s"Money operation resulted in an overflow. $amount is too big or small.")
 
 sealed trait BaseMoney {
   def `type`: String
@@ -75,9 +75,9 @@ object BaseMoney {
       val empty: BaseMoney = Money.zero(c)
     }
 
-  private[util] def bigDecimalToMoneyLong(bigDecimal: BigDecimal): Long =
-    try bigDecimal.toLongExact
-    catch { case _: ArithmeticException => throw new MoneyOverflowException(bigDecimal) }
+  private[util] def bigDecimalToMoneyLong(amount: BigDecimal): Long =
+    try amount.toLongExact
+    catch { case _: ArithmeticException => throw new MoneyOverflowException(amount) }
 }
 
 /** Represents an amount of money in a certain currency.

--- a/util/src/main/scala/Money.scala
+++ b/util/src/main/scala/Money.scala
@@ -16,7 +16,8 @@ import ValidatedFlatMapFeature._
 import io.sphere.util.BaseMoney.bigDecimalToMoneyLong
 import io.sphere.util.Money.ImplicitsDecimal.MoneyNotation
 
-class MoneyOverflowException extends RuntimeException("A Money operation resulted in an overflow.")
+class MoneyOverflowException
+    extends ArithmeticException("A Money operation resulted in an overflow.")
 
 sealed trait BaseMoney {
   def `type`: String

--- a/util/src/main/scala/Money.scala
+++ b/util/src/main/scala/Money.scala
@@ -16,9 +16,7 @@ import ValidatedFlatMapFeature._
 import io.sphere.util.BaseMoney.bigDecimalToMoneyLong
 import io.sphere.util.Money.ImplicitsDecimal.MoneyNotation
 
-class MoneyOverflowException(amount: BigDecimal)
-    extends RuntimeException(
-      s"Money operation resulted in an overflow. $amount is too big or small.")
+class MoneyOverflowException extends RuntimeException("A Money operation resulted in an overflow.")
 
 sealed trait BaseMoney {
   def `type`: String
@@ -77,7 +75,7 @@ object BaseMoney {
 
   private[util] def bigDecimalToMoneyLong(amount: BigDecimal): Long =
     try amount.toLongExact
-    catch { case _: ArithmeticException => throw new MoneyOverflowException(amount) }
+    catch { case _: ArithmeticException => throw new MoneyOverflowException }
 }
 
 /** Represents an amount of money in a certain currency.

--- a/util/src/main/scala/Money.scala
+++ b/util/src/main/scala/Money.scala
@@ -16,7 +16,7 @@ import ValidatedFlatMapFeature._
 import io.sphere.util.BaseMoney.bigDecimalToMoneyLong
 import io.sphere.util.Money.ImplicitsDecimal.MoneyNotation
 
-final case class MoneyOverflowException(number: BigDecimal)
+class MoneyOverflowException(number: BigDecimal)
     extends RuntimeException(
       s"Money operation resulted in an overflow. $number is too big or small.")
 
@@ -77,7 +77,7 @@ object BaseMoney {
 
   private[util] def bigDecimalToMoneyLong(bigDecimal: BigDecimal): Long =
     try bigDecimal.toLongExact
-    catch { case _: ArithmeticException => throw MoneyOverflowException(bigDecimal) }
+    catch { case _: ArithmeticException => throw new MoneyOverflowException(bigDecimal) }
 }
 
 /** Represents an amount of money in a certain currency.

--- a/util/src/test/scala/HighPrecisionMoneySpec.scala
+++ b/util/src/test/scala/HighPrecisionMoneySpec.scala
@@ -2,6 +2,7 @@ package io.sphere.util
 
 import java.util.Currency
 import cats.data.Validated.Invalid
+import io.sphere.util.HighPrecisionMoney.ImplicitsDecimalPrecise.HighPrecisionPreciseMoneyNotation
 import org.scalatest.funspec.AnyFunSpec
 import org.scalatestplus.scalacheck.ScalaCheckDrivenPropertyChecks
 import org.scalatest.matchers.must.Matchers
@@ -45,6 +46,12 @@ class HighPrecisionMoneySpec extends AnyFunSpec with Matchers with ScalaCheckDri
       -"0.01".EUR_PRECISE(2) must equal("-0.01".EUR_PRECISE(2))
     }
 
+    it("should throw error on overflow in the unary '-' operator.") {
+      a[MoneyOverflowException] must be thrownBy {
+        -(BigDecimal(Long.MinValue) / 1000).EUR_PRECISE(3)
+      }
+    }
+
     it("should support the binary '+' operator.") {
       ("0.001".EUR_PRECISE(3)) + ("0.002".EUR_PRECISE(3)) must equal(
         "0.003".EUR_PRECISE(3)
@@ -57,6 +64,12 @@ class HighPrecisionMoneySpec extends AnyFunSpec with Matchers with ScalaCheckDri
       ("0.005".EUR_PRECISE(3)) + BigDecimal("0.005") must equal(
         "0.010".EUR_PRECISE(3)
       )
+    }
+
+    it("should throw error on overflow in the binary '+' operator.") {
+      a[MoneyOverflowException] must be thrownBy {
+        (BigDecimal(Long.MaxValue) / 1000).EUR_PRECISE(3) + 1
+      }
     }
 
     it("should support the binary '-' operator.") {
@@ -73,6 +86,12 @@ class HighPrecisionMoneySpec extends AnyFunSpec with Matchers with ScalaCheckDri
       )
     }
 
+    it("should throw error on overflow in the binary '-' operator.") {
+      a[MoneyOverflowException] must be thrownBy {
+        (BigDecimal(Long.MinValue) / 1000).EUR_PRECISE(3) - 1
+      }
+    }
+
     it("should support the binary '*' operator.") {
       ("0.002".EUR_PRECISE(3)) * ("5.00".EUR_PRECISE(2)) must equal(
         "0.010".EUR_PRECISE(3)
@@ -85,6 +104,12 @@ class HighPrecisionMoneySpec extends AnyFunSpec with Matchers with ScalaCheckDri
       ("0.005".EUR_PRECISE(3)) * BigDecimal("0.005") must equal(
         "0.000".EUR_PRECISE(3)
       )
+    }
+
+    it("should throw error on overflow in the binary '*' operator.") {
+      a[MoneyOverflowException] must be thrownBy {
+        (BigDecimal(Long.MaxValue / 1000) / 2 + 1).EUR_PRECISE(3) * 2
+      }
     }
 
     it("should support the binary '%' operator.") {
@@ -101,16 +126,34 @@ class HighPrecisionMoneySpec extends AnyFunSpec with Matchers with ScalaCheckDri
       )
     }
 
+    it("should throw error on overflow in the binary '%' operator.") {
+      noException must be thrownBy {
+        BigDecimal(Long.MaxValue / 1000).EUR_PRECISE(3) % 0.5
+      }
+    }
+
     it("should support the binary '/%' operator.") {
       "10.000".EUR_PRECISE(3)./%(3.00) must equal(
         ("3.000".EUR_PRECISE(3), "1.000".EUR_PRECISE(3))
       )
     }
 
+    it("should throw error on overflow in the binary '/%' operator.") {
+      a[MoneyOverflowException] must be thrownBy {
+        BigDecimal(Long.MaxValue / 1000).EUR_PRECISE(3) /% 0.5
+      }
+    }
+
     it("should support the remainder operator.") {
       "10.000".EUR_PRECISE(3).remainder(3.00) must equal("1.000".EUR_PRECISE(3))
 
       "10.000".EUR_PRECISE(3).remainder("3.000".EUR_PRECISE(3)) must equal("1.000".EUR_PRECISE(3))
+    }
+
+    it("should not overflow when getting the remainder of a division ('%').") {
+      noException must be thrownBy {
+        BigDecimal(Long.MaxValue / 1000).EUR_PRECISE(3).remainder(0.5)
+      }
     }
 
     it("should partition the value properly.") {


### PR DESCRIPTION
Until now, all `BaseMoney` implementations, namely cent precision `Money` and `HighPrecisionMoney`, would silently overflow and become negative when their underlying `Long` representation exceeded `Long.MaxValue`.
This PR turns these silent overflows into LOUD EXCEPTIONS.

Since we have already decided to implement money using fixed length longs, we cannot represent all possible money values. When we encounter such unrepresentable values it's arguably better to throw an exception, instead of silently continuing with wrong values.