### PR TITLE
Failing test for the issue

### DIFF
--- a/json/json-derivation/src/main/scala/io/sphere/json/generic/JSONMacros.scala
+++ b/json/json-derivation/src/main/scala/io/sphere/json/generic/JSONMacros.scala
@@ -167,6 +167,7 @@ private[generic] object JSONMacros {
         )
       else {
         val subtypes = collectKnownSubtypes(c)(symbol)
+        c.info(c.enclosingPosition, symbol.fullName + " Subtypes: " + subtypes.mkString(", "), true)
         val idents = Ident(symbol.name) :: subtypes.map { s =>
           if (s.isModuleClass) New(TypeTree(s.asClass.toType)) else Ident(s.name)
         }.toList

--- a/json/json-derivation/src/test/scala/io/sphere/json/AnotherFileExample.scala
+++ b/json/json-derivation/src/test/scala/io/sphere/json/AnotherFileExample.scala
@@ -1,0 +1,17 @@
+package io.sphere.json
+
+object AnotherFileExample {
+  sealed abstract class Bug {
+    def name: String
+    def legs: Int
+  }
+  abstract class Insect extends Bug {
+    def legs = 6
+  }
+  case class Spider(name: String) extends Bug {
+    def legs = 8
+  }
+
+  case class Ant(name: String) extends Insect
+  case class Grasshopper(name: String) extends Insect
+}

--- a/json/json-derivation/src/test/scala/io/sphere/json/MultiFileJSONSpec.scala
+++ b/json/json-derivation/src/test/scala/io/sphere/json/MultiFileJSONSpec.scala
@@ -1,0 +1,17 @@
+package io.sphere.json
+
+import io.sphere.json.generic._
+import org.scalatest.OptionValues
+import org.scalatest.matchers.must.Matchers
+import org.scalatest.wordspec.AnyWordSpec
+import cats.data.Validated.Valid
+import io.sphere.json.AnotherFileExample._
+class MultiFileJSONSpec extends AnyWordSpec with Matchers with OptionValues {
+  "deriveJSON" should {
+    "handle classes in another file correctly" in {
+      implicit val bugJSON = deriveJSON[Bug]
+      val a = Ant("C. ligniperda")
+      fromJSON[Bug](toJSON[Bug](a)) must equal(Valid(a))
+    }
+  }
+}


### PR DESCRIPTION
In Sphere I discovered the macro doesn't work across files 🤔 

For now just a failing test to demonstrate the issue, perhaps I'll dig into it on a tech day to fix it.

Specifically it's not correctly detecting the subtypes
```
[info] /Users/martinwelgemoed/commercetools/sphere-scala-libs/json/json-derivation/src/test/scala/io/sphere/json/MultiFileJSONSpec.scala:12:40: io.sphere.json.AnotherFileExample.Bug Subtypes: class Spider
[info]       implicit val bugJSON = deriveJSON[Bug]
```