### PR TITLE
Reverting Jackson 2.15 update

### DIFF
--- a/json/json-core/dependencies.sbt
+++ b/json/json-core/dependencies.sbt
@@ -1,5 +1,5 @@
 libraryDependencies ++= Seq(
   "org.json4s" %% "json4s-jackson" % "4.0.6",
-  "com.fasterxml.jackson.core" % "jackson-databind" % "2.15.2",
+  "com.fasterxml.jackson.core" % "jackson-databind" % "2.14.2",
   "org.typelevel" %% "cats-core" % "2.9.0"
 )

--- a/json/json-core/src/main/scala/io/sphere/json/package.scala
+++ b/json/json-core/src/main/scala/io/sphere/json/package.scala
@@ -3,7 +3,7 @@ package io.sphere
 import cats.data.Validated.{Invalid, Valid}
 import cats.data.{NonEmptyList, ValidatedNel}
 import com.fasterxml.jackson.core.JsonParseException
-import com.fasterxml.jackson.core.exc.{InputCoercionException, StreamConstraintsException}
+import com.fasterxml.jackson.core.exc.InputCoercionException
 import com.fasterxml.jackson.databind.JsonMappingException
 import io.sphere.util.Logging
 import org.json4s.{DefaultFormats, JsonInput, StringInput}
@@ -28,7 +28,6 @@ package object json extends Logging {
       case e: JsonMappingException => jsonParseError(e.getOriginalMessage)
       case e: JsonParseException => jsonParseError(e.getOriginalMessage)
       case e: InputCoercionException => jsonParseError(e.getOriginalMessage)
-      case e: StreamConstraintsException => jsonParseError(e.getOriginalMessage)
     }
 
   def parseJSON(json: String): JValidation[JValue] =


### PR DESCRIPTION
A [support ticket](https://commercetools.atlassian.net/browse/SUPPORT-21730) has been raised that large custom objects fail, even if they are below the documented limit of 16MB. The error:
```String length (5046272) exceeds the maximum length (5000000)```
suggests that it might be tied to a recent [Jackson library update](https://github.com/FasterXML/jackson-core/issues/1001) ([here’s our PR](https://github.com/commercetools/sphere-scala-libs/pull/488/files) bumping to 2.15). Since this is Jackson, the change affects the entire backend.

For now we will revert this update and implement as a follow-up.