### PR TITLE
Update Jackson to 2.15

### DIFF
--- a/json/json-core/dependencies.sbt
+++ b/json/json-core/dependencies.sbt
@@ -1,5 +1,5 @@
 libraryDependencies ++= Seq(
   "org.json4s" %% "json4s-jackson" % "4.0.6",
-  "com.fasterxml.jackson.core" % "jackson-databind" % "2.14.2",
+  "com.fasterxml.jackson.core" % "jackson-databind" % "2.15.2",
   "org.typelevel" %% "cats-core" % "2.9.0"
 )

--- a/json/json-core/src/main/scala/io/sphere/json/package.scala
+++ b/json/json-core/src/main/scala/io/sphere/json/package.scala
@@ -3,7 +3,7 @@ package io.sphere
 import cats.data.Validated.{Invalid, Valid}
 import cats.data.{NonEmptyList, ValidatedNel}
 import com.fasterxml.jackson.core.JsonParseException
-import com.fasterxml.jackson.core.exc.InputCoercionException
+import com.fasterxml.jackson.core.exc.{InputCoercionException, StreamConstraintsException}
 import com.fasterxml.jackson.databind.JsonMappingException
 import io.sphere.util.Logging
 import org.json4s.{DefaultFormats, JsonInput, StringInput}
@@ -28,6 +28,7 @@ package object json extends Logging {
       case e: JsonMappingException => jsonParseError(e.getOriginalMessage)
       case e: JsonParseException => jsonParseError(e.getOriginalMessage)
       case e: InputCoercionException => jsonParseError(e.getOriginalMessage)
+      case e: StreamConstraintsException => jsonParseError(e.getOriginalMessage)
     }
 
   def parseJSON(json: String): JValidation[JValue] =

--- a/json/json-core/src/test/scala/io/sphere/json/SphereJsonParserSpec.scala
+++ b/json/json-core/src/test/scala/io/sphere/json/SphereJsonParserSpec.scala
@@ -1,0 +1,14 @@
+package io.sphere.json
+
+import org.scalatest.matchers.must.Matchers
+import org.scalatest.wordspec.AnyWordSpec
+
+class SphereJsonParserSpec extends AnyWordSpec with Matchers {
+  "Object mapper" must {
+
+    "accept strings with 20_000_000 bytes" in {
+      SphereJsonParser.mapper.getFactory.streamReadConstraints().getMaxStringLength must be(
+        20000000)
+    }
+  }
+}


### PR DESCRIPTION
This PR brings back Jackson to the 2.15.2 version (from before #507). Initially this PR was supposed to contain additional changes that increased `StreamReadConstraints.maxStringLength` above the default `5_000_000` limit from the `2.15` version. Turns out that the [2.15.1 release](https://github.com/FasterXML/jackson/wiki/Jackson-Release-2.15.1) already increased the limit from 5Mb to 20Mb which solves our issues.