### PR TITLE
Fix for reading Some(Map.empty)

### DIFF
--- a/json/json-core/src/main/scala/io/sphere/json/FromJSON.scala
+++ b/json/json-core/src/main/scala/io/sphere/json/FromJSON.scala
@@ -39,6 +39,17 @@ object FromJSON extends FromJSONInstances {
   private def validEmptyVector[A]: Valid[Vector[A]] =
     validEmptyAnyVector.asInstanceOf[Valid[Vector[A]]]
 
+  implicit def optionMapReader[@specialized A](implicit
+      c: FromJSON[A]): FromJSON[Option[Map[String, A]]] =
+    new FromJSON[Option[Map[String, A]]] {
+      private val internalMapReader = mapReader[A]
+
+      def read(jval: JValue): JValidation[Option[Map[String, A]]] = jval match {
+        case JNothing | JNull => validNone
+        case x => internalMapReader.read(x).map(Some.apply)
+      }
+    }
+
   implicit def optionReader[@specialized A](implicit c: FromJSON[A]): FromJSON[Option[A]] =
     new FromJSON[Option[A]] {
       def read(jval: JValue): JValidation[Option[A]] = jval match {

--- a/json/json-derivation/src/test/scala/io/sphere/json/OptionReaderSpec.scala
+++ b/json/json-derivation/src/test/scala/io/sphere/json/OptionReaderSpec.scala
@@ -1,6 +1,7 @@
 package io.sphere.json
 
 import io.sphere.json.generic._
+import org.json4s.{JLong, JObject, JString}
 import org.scalatest.OptionValues
 import org.scalatest.matchers.must.Matchers
 import org.scalatest.wordspec.AnyWordSpec
@@ -19,6 +20,10 @@ object OptionReaderSpec {
     implicit val json: JSON[ComplexClass] = jsonProduct(apply _)
   }
 
+  case class MapClass(id: Long, map: Option[Map[String, String]])
+  object MapClass {
+    implicit val json: JSON[MapClass] = jsonProduct(apply _)
+  }
 }
 
 class OptionReaderSpec extends AnyWordSpec with Matchers with OptionValues {
@@ -59,6 +64,17 @@ class OptionReaderSpec extends AnyWordSpec with Matchers with OptionValues {
       val json = "{}"
       val result = getFromJSON[Option[SimpleClass]](json)
       result mustEqual None
+    }
+
+    "handle optional map" in {
+      getFromJValue[MapClass](JObject("id" -> JLong(1L))) mustEqual MapClass(1L, None)
+
+      getFromJValue[MapClass](JObject("id" -> JLong(1L), "map" -> JObject())) mustEqual
+        MapClass(1L, Some(Map.empty))
+
+      getFromJValue[MapClass](
+        JObject("id" -> JLong(1L), "map" -> JObject("a" -> JString("b")))) mustEqual
+        MapClass(1L, Some(Map("a" -> "b")))
     }
 
     "handle absence of all fields mixed with ignored fields" in {

--- a/json/json-derivation/src/test/scala/io/sphere/json/OptionReaderSpec.scala
+++ b/json/json-derivation/src/test/scala/io/sphere/json/OptionReaderSpec.scala
@@ -1,7 +1,7 @@
 package io.sphere.json
 
 import io.sphere.json.generic._
-import org.json4s.{JLong, JObject, JString}
+import org.json4s.{JLong, JNothing, JObject, JString}
 import org.scalatest.OptionValues
 import org.scalatest.matchers.must.Matchers
 import org.scalatest.wordspec.AnyWordSpec
@@ -75,6 +75,13 @@ class OptionReaderSpec extends AnyWordSpec with Matchers with OptionValues {
       getFromJValue[MapClass](
         JObject("id" -> JLong(1L), "map" -> JObject("a" -> JString("b")))) mustEqual
         MapClass(1L, Some(Map("a" -> "b")))
+
+      toJValue[MapClass](MapClass(1L, None)) mustEqual
+        JObject("id" -> JLong(1L), "map" -> JNothing)
+      toJValue[MapClass](MapClass(1L, Some(Map()))) mustEqual
+        JObject("id" -> JLong(1L), "map" -> JObject())
+      toJValue[MapClass](MapClass(1L, Some(Map("a" -> "b")))) mustEqual
+        JObject("id" -> JLong(1L), "map" -> JObject("a" -> JString("b")))
     }
 
     "handle absence of all fields mixed with ignored fields" in {


### PR DESCRIPTION
A small failing test plus my suggested fix for what I think may be a bug in how it handles empty maps in an option. 🤔 

Specifically `{}` in json when read into a `Option[Map[String, _]]` becomes `None` instead of `Map.empty`.