### PR TITLE
Introduce MongoProvidedFormat to skip generating MongoFormatters. Now…

### DIFF
--- a/mongo/mongo-derivation/src/main/java/io/sphere/mongo/generic/annotations/MongoProvidedFormatter.java
+++ b/mongo/mongo-derivation/src/main/java/io/sphere/mongo/generic/annotations/MongoProvidedFormatter.java
@@ -1,0 +1,12 @@
+package io.sphere.mongo.generic.annotations;
+
+import java.lang.annotation.Target;
+
+import static java.lang.annotation.ElementType.TYPE;
+
+/**
+ * A subtype marked with MongoProvidedFormatter will use the custom provided formatter instead of the automatically generated one.
+ */
+@Target({TYPE})
+public @interface MongoProvidedFormatter {
+}

--- a/mongo/mongo-derivation/src/main/scala/io/sphere/mongo/generic/package.fmpp.scala
+++ b/mongo/mongo-derivation/src/main/scala/io/sphere/mongo/generic/package.fmpp.scala
@@ -166,7 +166,7 @@ package object generic extends Logging {
   def mongoTypeSwitch[T: ClassTag, ${implTypeParams}](selectors: List[TypeSelector[_]]): MongoFormat[T] = mongoTypeSwitch[T, ${typeParams}](typeSelector[A${i}]() :: selectors)
   </#list>
 
-  final class TypeSelector[A: MongoFormat] private[mongo](val typeField: String, val typeValue: String, val clazz: Class[_]) {
+  final class TypeSelector[A: MongoFormat] private[mongo](val typeValue: String, val clazz: Class[_]) {
     def read(any: Any): A = fromMongo[A](any)
     def write(a: Any): Any = toMongo[A](a.asInstanceOf[A])
   }
@@ -263,7 +263,7 @@ package object generic extends Logging {
       case Some(hint) => (hint.field, hint.value)
       case None => (defaultTypeFieldName, defaultTypeValue(clazz))
     }
-    new TypeSelector[A](typeField, typeValue, clazz)
+    new TypeSelector[A](typeValue, clazz)
   }
 
   private def defaultTypeValue(clazz: Class[_]): String =


### PR DESCRIPTION
… the skipping can also handle types with parameters.

* This was necessary because we realized that the type we actually want to skip has one type parameter. 
* This code cannot handle more than 1 type parameters for now. 
* We switched from the automatic approach to one that uses annotations, I'm not 100% sure this is better, but the code is simpler. 