### PR TITLE
Downgrade mongo-driver-core to 4.10.2

### DIFF
--- a/mongo/mongo-core/dependencies.sbt
+++ b/mongo/mongo-core/dependencies.sbt
@@ -1,3 +1,3 @@
 libraryDependencies ++= Seq(
-  "org.mongodb" % "mongodb-driver-core" % "4.11.0" // tracking http://mongodb.github.io/mongo-java-driver/
+  "org.mongodb" % "mongodb-driver-core" % "4.10.2" // tracking http://mongodb.github.io/mongo-java-driver/
 )


### PR DESCRIPTION
* 4.11.0 caused some transitive dependency errors, so let's wait a bit until other libraries upgrade their versions too. 