### PR TITLE
Priceless owns Money

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,3 +1,6 @@
 # why this file: to pick reviewers for a pull request automatically
 # doc on https://help.github.com/articles/about-codeowners/
 *       @yanns
+
+# Priceless backend team domain
+*Money*.scala @commercetools/priceless-team-be


### PR DESCRIPTION
Initiating the [Security Champions initiative](https://commercetools.atlassian.net/browse/PRC-3318) in the Priceless team, we are tagging everything related to `Money` to us (without actually getting rich).

I tried to test the pattern and it seems that everything money-related is covered:
<img width="710" alt="Screenshot 2024-02-13 at 15 09 01" src="https://github.com/commercetools/sphere-scala-libs/assets/83928/51a5105a-a98f-4114-a3d8-ad83a132ea1d">
