### PR TITLE
[ENE-49] Fix infinite loop in derivation

### DIFF
--- a/mongo/mongo-derivation-scala-3/src/main/scala/io/sphere/mongo/generic/Derivation.scala
+++ b/mongo/mongo-derivation-scala-3/src/main/scala/io/sphere/mongo/generic/Derivation.scala
@@ -27,9 +27,11 @@ private final class NativeMongoFormat[A <: SimpleMongoType] extends TypedMongoFo
   def fromMongoValue(any: MongoType): A = any.asInstanceOf[A]
 }
 
-inline def deriveMongoFormat[A: TypedMongoFormat]: TypedMongoFormat[A] = summon
+inline def deriveMongoFormat[A](using Mirror.Of[A]): TypedMongoFormat[A] = TypedMongoFormat.derived
 
 object TypedMongoFormat:
+  inline def apply[A: TypedMongoFormat]: TypedMongoFormat[A] = summon
+
   private val emptyFieldsSet: Vector[String] = Vector.empty
   inline def readCaseClassMetaData[T]: CaseClassMetaData = ${ readCaseClassMetaDataImpl[T] }
 
@@ -41,7 +43,7 @@ object TypedMongoFormat:
   private def readTraitMetaDataImpl[T: Type](using Quotes): Expr[TraitMetaData] =
     AnnotationReader().readTraitMetaData[T]
 
-  inline given derive[A](using Mirror.Of[A]): TypedMongoFormat[A] = Derivation.derived
+  inline given derived[A](using Mirror.Of[A]): TypedMongoFormat[A] = Derivation.derived
 
   given TypedMongoFormat[Int] = new NativeMongoFormat[Int]
   given TypedMongoFormat[String] = new NativeMongoFormat[String]

--- a/mongo/mongo-derivation-scala-3/src/test/scala/io/sphere/mongo/SerializationTest.scala
+++ b/mongo/mongo-derivation-scala-3/src/test/scala/io/sphere/mongo/SerializationTest.scala
@@ -28,15 +28,15 @@ class SerializationTest extends AnyWordSpec with Matchers:
       dbo.put("a", Integer.valueOf(3))
       dbo.put("b", Integer.valueOf(4))
 
-      // Using backwards-compatible `deriveMongoFormat`
-      given TypedMongoFormat[Something] = io.sphere.mongo.generic.deriveMongoFormat
+      // Using backwards-compatible `deriveMongoFormat` + `implicit`
+      implicit val x: TypedMongoFormat[Something] = io.sphere.mongo.generic.deriveMongoFormat
 
       val something = TypedMongoFormat[Something].fromMongoValue(dbo)
       something mustBe Something(Some(3), 4)
     }
 
     "generate a format that serializes optional fields with value None as BSON objects without that field" in {
-      // Using new Scala 3 `derived` special method
+      // Using new Scala 3 `derived` special method + `given`
       given TypedMongoFormat[Something] = TypedMongoFormat.derived
 
       val something = Something(None, 1)


### PR DESCRIPTION
When writing a code like: 
```implicit val x: TypedMongoFormat[Something] = io.sphere.mongo.generic.deriveMongoFormat``` 

or 
```given TypedMongoFormat[Something] = io.sphere.mongo.generic.deriveMongoFormat``` 

A compile error happens due to an infinite loop in the derivation process.

This PR aims to fix that, and also add some new features: 

- TypedMongoFormat now has an `inline apply` method cats-style to summon an instance at 0 cost.
- Verification that the `derives` directive also works (at least for Product types). 
- Specs for different ways to derive and summon instances (`given`, `implicit`, automatic).