### PR TITLE
Add support for `java.time` JSON conversions

### DIFF
--- a/json/json-core/src/main/scala/io/sphere/json/FromJSON.scala
+++ b/json/json-core/src/main/scala/io/sphere/json/FromJSON.scala
@@ -392,7 +392,7 @@ object FromJSON extends FromJSONInstances {
       time.LocalDate.parse(_, time.format.DateTimeFormatter.ISO_LOCAL_DATE))
 
   implicit val javaYearMonthReader: FromJSON[time.YearMonth] =
-    jsonStringReader("Failed to parse year/month: %s")(time.YearMonth.parse(_))
+    jsonStringReader("Failed to parse year/month: %s")(time.YearMonth.parse(_, JavaYearMonthFormatter))
 
   implicit val uuidReader: FromJSON[UUID] = jsonStringReader("Invalid UUID: '%s'")(UUID.fromString)
 

--- a/json/json-core/src/main/scala/io/sphere/json/FromJSON.scala
+++ b/json/json-core/src/main/scala/io/sphere/json/FromJSON.scala
@@ -11,10 +11,15 @@ import cats.syntax.traverse._
 import io.sphere.json.field
 import io.sphere.util.{BaseMoney, HighPrecisionMoney, LangTag, Money}
 import org.json4s.JsonAST._
-import org.joda.time._
 import org.joda.time.format.ISODateTimeFormat
 
 import scala.annotation.implicitNotFound
+import java.time
+import org.joda.time.DateTime
+import org.joda.time.DateTimeZone
+import org.joda.time.YearMonth
+import org.joda.time.LocalTime
+import org.joda.time.LocalDate
 
 /** Type class for types that can be read from JSON. */
 @implicitNotFound("Could not find an instance of FromJSON for ${A}")
@@ -341,6 +346,7 @@ object FromJSON extends FromJSONInstances {
       }
     }
 
+  // Joda Time
   implicit val dateTimeReader: FromJSON[DateTime] = {
     val UTCDateTimeComponents = raw"(\d{4})-(\d{2})-(\d{2})T(\d{2}):(\d{2}):(\d{2})\.(\d{3})Z".r
 
@@ -372,6 +378,21 @@ object FromJSON extends FromJSONInstances {
     jsonStringReader("Failed to parse year/month: %s") {
       new YearMonth(_)
     }
+
+  // java.time
+  implicit val javaInstantReader: FromJSON[time.Instant] =
+    jsonStringReader("Failed to parse date/time: %s")(time.Instant.parse(_))
+
+  implicit val javaLocalTimeReader: FromJSON[time.LocalTime] =
+    jsonStringReader("Failed to parse time: %s")(
+      time.LocalTime.parse(_, time.format.DateTimeFormatter.ISO_LOCAL_TIME))
+
+  implicit val javaLocalDateReader: FromJSON[time.LocalDate] =
+    jsonStringReader("Failed to parse date: %s")(
+      time.LocalDate.parse(_, time.format.DateTimeFormatter.ISO_LOCAL_DATE))
+
+  implicit val javaYearMonthReader: FromJSON[time.YearMonth] =
+    jsonStringReader("Failed to parse year/month: %s")(time.YearMonth.parse(_))
 
   implicit val uuidReader: FromJSON[UUID] = jsonStringReader("Invalid UUID: '%s'")(UUID.fromString)
 

--- a/json/json-core/src/main/scala/io/sphere/json/FromJSON.scala
+++ b/json/json-core/src/main/scala/io/sphere/json/FromJSON.scala
@@ -392,7 +392,8 @@ object FromJSON extends FromJSONInstances {
       time.LocalDate.parse(_, time.format.DateTimeFormatter.ISO_LOCAL_DATE))
 
   implicit val javaYearMonthReader: FromJSON[time.YearMonth] =
-    jsonStringReader("Failed to parse year/month: %s")(time.YearMonth.parse(_, JavaYearMonthFormatter))
+    jsonStringReader("Failed to parse year/month: %s")(
+      time.YearMonth.parse(_, JavaYearMonthFormatter))
 
   implicit val uuidReader: FromJSON[UUID] = jsonStringReader("Invalid UUID: '%s'")(UUID.fromString)
 

--- a/json/json-core/src/main/scala/io/sphere/json/ToJSON.scala
+++ b/json/json-core/src/main/scala/io/sphere/json/ToJSON.scala
@@ -5,10 +5,15 @@ import java.util.{Currency, Locale, UUID}
 
 import io.sphere.util.{BaseMoney, HighPrecisionMoney, Money}
 import org.json4s.JsonAST._
-import org.joda.time._
+import org.joda.time.DateTime
+import org.joda.time.DateTimeZone
+import org.joda.time.LocalTime
+import org.joda.time.LocalDate
+import org.joda.time.YearMonth
 import org.joda.time.format.ISODateTimeFormat
 
 import scala.annotation.implicitNotFound
+import java.time
 
 /** Type class for types that can be written to JSON. */
 @implicitNotFound("Could not find an instance of ToJSON for ${A}")
@@ -161,6 +166,7 @@ object ToJSON extends ToJSONInstances {
     def write(u: Unit): JValue = JNothing
   }
 
+  // Joda time
   implicit val dateTimeWriter: ToJSON[DateTime] = new ToJSON[DateTime] {
     def write(dt: DateTime): JValue = JString(
       ISODateTimeFormat.dateTime.print(dt.withZone(DateTimeZone.UTC)))
@@ -176,6 +182,26 @@ object ToJSON extends ToJSONInstances {
 
   implicit val yearMonthWriter: ToJSON[YearMonth] = new ToJSON[YearMonth] {
     def write(ym: YearMonth): JValue = JString(ISODateTimeFormat.yearMonth().print(ym))
+  }
+
+  // java.time
+  implicit val javaInstantWriter: ToJSON[time.Instant] = new ToJSON[time.Instant] {
+    def write(value: time.Instant): JValue = JString(
+      time.format.DateTimeFormatter.ISO_INSTANT.format(value))
+  }
+
+  implicit val javaTimeWriter: ToJSON[time.LocalTime] = new ToJSON[time.LocalTime] {
+    def write(value: time.LocalTime): JValue = JString(
+      time.format.DateTimeFormatter.ISO_LOCAL_TIME.format(value))
+  }
+
+  implicit val javaDateWriter: ToJSON[time.LocalDate] = new ToJSON[time.LocalDate] {
+    def write(value: time.LocalDate): JValue = JString(
+      time.format.DateTimeFormatter.ISO_LOCAL_DATE.format(value))
+  }
+
+  implicit val javaYearMonth: ToJSON[time.YearMonth] = new ToJSON[time.YearMonth] {
+    def write(value: time.YearMonth): JValue = JString(value.toString())
   }
 
   implicit val uuidWriter: ToJSON[UUID] = new ToJSON[UUID] {

--- a/json/json-core/src/main/scala/io/sphere/json/ToJSON.scala
+++ b/json/json-core/src/main/scala/io/sphere/json/ToJSON.scala
@@ -201,7 +201,7 @@ object ToJSON extends ToJSONInstances {
   }
 
   implicit val javaYearMonth: ToJSON[time.YearMonth] = new ToJSON[time.YearMonth] {
-    def write(value: time.YearMonth): JValue = JString(value.toString())
+    def write(value: time.YearMonth): JValue = JString(JavaYearMonthFormatter.format(value))
   }
 
   implicit val uuidWriter: ToJSON[UUID] = new ToJSON[UUID] {

--- a/json/json-core/src/main/scala/io/sphere/json/package.scala
+++ b/json/json-core/src/main/scala/io/sphere/json/package.scala
@@ -10,11 +10,15 @@ import org.json4s.{DefaultFormats, JsonInput, StringInput}
 import org.json4s.JsonAST._
 import org.json4s.ParserUtil.ParseException
 import org.json4s.jackson.compactJson
+import java.time.format.DateTimeFormatter
 
 /** Provides functions for reading & writing JSON, via type classes JSON/JSONR/JSONW. */
 package object json extends Logging {
 
-  implicit val liftJsonFormats = DefaultFormats
+  private[json] val JavaYearMonthFormatter =
+    DateTimeFormatter.ofPattern("uuuu-MM")
+
+  implicit val liftJsonFormats: DefaultFormats = DefaultFormats
 
   type JValidation[A] = ValidatedNel[JSONError, A]
 

--- a/json/json-core/src/test/scala/io/sphere/json/DateTimeParsingSpec.scala
+++ b/json/json-core/src/test/scala/io/sphere/json/DateTimeParsingSpec.scala
@@ -7,6 +7,7 @@ import org.scalatest.wordspec.AnyWordSpec
 class DateTimeParsingSpec extends AnyWordSpec with Matchers {
 
   import FromJSON.dateTimeReader
+  import FromJSON.javaInstantReader
   def jsonDateStringWith(
       year: String = "2035",
       dayOfTheMonth: String = "23",
@@ -61,6 +62,49 @@ class DateTimeParsingSpec extends AnyWordSpec with Matchers {
 
     "reject strings with invalid seconds" in {
       dateTimeReader.read(jsonDateStringWith(secondOfTheMinute = "87")) shouldNot beValid
+    }
+  }
+
+  "parsing an Instant" should {
+
+    "reject strings with invalid year" in {
+      javaInstantReader.read(jsonDateStringWith(year = "999999999")) shouldNot beValid
+    }
+
+    "reject strings with years that are out of range for integers" in {
+      javaInstantReader.read(jsonDateStringWith(year = outOfIntRange)) shouldNot beValid
+    }
+
+    "reject strings that are out of range for other fields" in {
+      javaInstantReader.read(
+        jsonDateStringWith(
+          monthOfTheYear = outOfIntRange,
+          dayOfTheMonth = outOfIntRange,
+          hourOfTheDay = outOfIntRange,
+          minuteOfTheHour = outOfIntRange,
+          secondOfTheMinute = outOfIntRange,
+          millis = outOfIntRange
+        )) shouldNot beValid
+    }
+
+    "reject strings with invalid days" in {
+      javaInstantReader.read(jsonDateStringWith(dayOfTheMonth = "59")) shouldNot beValid
+    }
+
+    "reject strings with invalid months" in {
+      javaInstantReader.read(jsonDateStringWith(monthOfTheYear = "39")) shouldNot beValid
+    }
+
+    "reject strings with invalid hours" in {
+      javaInstantReader.read(jsonDateStringWith(hourOfTheDay = "39")) shouldNot beValid
+    }
+
+    "reject strings with invalid minutes" in {
+      javaInstantReader.read(jsonDateStringWith(minuteOfTheHour = "87")) shouldNot beValid
+    }
+
+    "reject strings with invalid seconds" in {
+      javaInstantReader.read(jsonDateStringWith(secondOfTheMinute = "87")) shouldNot beValid
     }
   }
 }

--- a/json/json-core/src/test/scala/io/sphere/json/JSONProperties.scala
+++ b/json/json-core/src/test/scala/io/sphere/json/JSONProperties.scala
@@ -9,6 +9,7 @@ import cats.data.NonEmptyList
 import cats.syntax.eq._
 import org.joda.time._
 import org.scalacheck._
+import java.time
 
 import scala.math.BigDecimal.RoundingMode
 
@@ -74,27 +75,31 @@ object JSONProperties extends Properties("JSON") {
       least <- Arbitrary.arbitrary[Long]
     } yield new UUID(most, least))
 
-  implicit val currencyEqual = new Eq[Currency] {
+  implicit val currencyEqual: Eq[Currency] = new Eq[Currency] {
     def eqv(c1: Currency, c2: Currency) = c1.getCurrencyCode == c2.getCurrencyCode
   }
-  implicit val localeEqual = new Eq[Locale] {
+  implicit val localeEqual: Eq[Locale] = new Eq[Locale] {
     def eqv(l1: Locale, l2: Locale) = l1.toLanguageTag == l2.toLanguageTag
   }
-  implicit val moneyEqual = new Eq[Money] {
+  implicit val moneyEqual: Eq[Money] = new Eq[Money] {
     override def eqv(x: Money, y: Money): Boolean = x == y
   }
-  implicit val dateTimeEqual = new Eq[DateTime] {
+  implicit val dateTimeEqual: Eq[DateTime] = new Eq[DateTime] {
     def eqv(dt1: DateTime, dt2: DateTime) = dt1 == dt2
   }
-  implicit val localTimeEqual = new Eq[LocalTime] {
+  implicit val localTimeEqual: Eq[LocalTime] = new Eq[LocalTime] {
     def eqv(dt1: LocalTime, dt2: LocalTime) = dt1 == dt2
   }
-  implicit val localDateEqual = new Eq[LocalDate] {
+  implicit val localDateEqual: Eq[LocalDate] = new Eq[LocalDate] {
     def eqv(dt1: LocalDate, dt2: LocalDate) = dt1 == dt2
   }
-  implicit val yearMonthEqual = new Eq[YearMonth] {
+  implicit val yearMonthEqual: Eq[YearMonth] = new Eq[YearMonth] {
     def eqv(dt1: YearMonth, dt2: YearMonth) = dt1 == dt2
   }
+  implicit val javaInstantEqual: Eq[time.Instant] = Eq.fromUniversalEquals
+  implicit val javaLocalDateEqual: Eq[time.LocalDate] = Eq.fromUniversalEquals
+  implicit val javaLocalTimeEqual: Eq[time.LocalTime] = Eq.fromUniversalEquals
+  implicit val javaYearMonthEqual: Eq[time.YearMonth] = Eq.fromUniversalEquals
 
   private def checkC[C[_]](name: String)(implicit
       jri: FromJSON[C[Int]],
@@ -151,4 +156,8 @@ object JSONProperties extends Properties("JSON") {
   property("read/write LocalDate") = Prop.forAll((u: LocalDate) => check(u))
   property("read/write LocalTime") = Prop.forAll((u: LocalTime) => check(u))
   property("read/write YearMonth") = Prop.forAll((u: YearMonth) => check(u))
+  property("read/write java.time.Instant") = Prop.forAll((i: time.Instant) => check(i))
+  property("read/write java.time.LocalDate") = Prop.forAll((d: time.LocalDate) => check(d))
+  property("read/write java.time.LocalTime") = Prop.forAll((t: time.LocalTime) => check(t))
+  property("read/write java.time.YearMonth") = Prop.forAll((ym: time.YearMonth) => check(ym))
 }


### PR DESCRIPTION
Joda Time is deprecated, we need to support `java.time` types.