### PR TITLE
Enable Scala 3 cross-compilation on non-macro projects

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,8 +23,8 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        scala: [2.12.20, 2.13.16]
-        java: [temurin@17]
+        scala: [2.12.20, 2.13.16, 3.3.4]
+        java: [temurin@21]
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout current branch (full)
@@ -32,12 +32,12 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Setup Java (temurin@17)
-        if: matrix.java == 'temurin@17'
+      - name: Setup Java (temurin@21)
+        if: matrix.java == 'temurin@21'
         uses: actions/setup-java@v4
         with:
           distribution: temurin
-          java-version: 17
+          java-version: 21
           cache: sbt
 
       - name: Setup sbt
@@ -69,7 +69,7 @@ jobs:
       matrix:
         os: [ubuntu-latest]
         scala: [2.13.16]
-        java: [temurin@17]
+        java: [temurin@21]
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout current branch (full)
@@ -77,12 +77,12 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Setup Java (temurin@17)
-        if: matrix.java == 'temurin@17'
+      - name: Setup Java (temurin@21)
+        if: matrix.java == 'temurin@21'
         uses: actions/setup-java@v4
         with:
           distribution: temurin
-          java-version: 17
+          java-version: 21
           cache: sbt
 
       - name: Setup sbt
@@ -104,6 +104,16 @@ jobs:
           name: target-${{ matrix.os }}-2.13.16-${{ matrix.java }}
 
       - name: Inflate target directories (2.13.16)
+        run: |
+          tar xf targets.tar
+          rm targets.tar
+
+      - name: Download target directories (3.3.4)
+        uses: actions/download-artifact@v4
+        with:
+          name: target-${{ matrix.os }}-3.3.4-${{ matrix.java }}
+
+      - name: Inflate target directories (3.3.4)
         run: |
           tar xf targets.tar
           rm targets.tar

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,6 +21,7 @@ jobs:
   build:
     name: Build and Test
     strategy:
+      fail-fast: false
       matrix:
         os: [ubuntu-latest]
         scala: [2.12.20, 2.13.16, 3.3.4]
@@ -49,8 +50,13 @@ jobs:
       - name: Check that workflows are up to date
         run: sbt '++ ${{ matrix.scala }}' githubWorkflowCheck
 
-      - name: Build project
+      - name: Build Scala 2 project
+        if: matrix.scala != '3.3.4'
         run: sbt '++ ${{ matrix.scala }}' test
+
+      - name: Build Scala 3 project
+        if: matrix.scala == '3.3.4'
+        run: sbt '++ ${{ matrix.scala }}' sphere-util/test sphere-json-core/test sphere-mongo-core/test
 
       - name: Compress target directories
         run: tar cf targets.tar benchmarks/target mongo/target json/json-core/target mongo/mongo-core/target json/target util/target json/json-derivation/target mongo/mongo-derivation-magnolia/target target mongo/mongo-derivation/target project/target

--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,4 @@ src_managed
 .metals
 metals.sbt
 .vscode
+*.worksheet.sc

--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,8 @@ plugins-ide.sbt
 src_managed
 *.deb
 *.changes
+.bloop
+.bsp
+.metals
+metals.sbt
+.vscode

--- a/build.sbt
+++ b/build.sbt
@@ -25,7 +25,8 @@ ThisBuild / githubWorkflowBuild := Seq(
   WorkflowStep.Sbt(
     commands = List("sphere-util/test", "sphere-json-core/test", "sphere-mongo-core/test"),
     name = Some("Build Scala 3 project"),
-    cond = Some(s"matrix.scala == '$scala3'"))
+    cond = Some(s"matrix.scala == '$scala3'")
+  )
 )
 
 // Release
@@ -105,7 +106,7 @@ lazy val `sphere-util` = project
 lazy val `sphere-json-core` = project
   .in(file("./json/json-core"))
   .settings(standardSettings: _*)
-  .settings(crossScalaVersions := Seq(scala212, scala213))
+  .settings(crossScalaVersions := Seq(scala212, scala213, scala3))
   .dependsOn(`sphere-util`)
 
 lazy val `sphere-json-derivation` = project

--- a/build.sbt
+++ b/build.sbt
@@ -1,10 +1,14 @@
 import pl.project13.scala.sbt.JmhPlugin
 
+lazy val scala212 = "2.12.20"
+lazy val scala213 = "2.13.16"
+lazy val scala3 = "3.3.4"
+
 // sbt-github-actions needs configuration in `ThisBuild`
-ThisBuild / crossScalaVersions := Seq("2.12.20", "2.13.16")
-ThisBuild / scalaVersion := crossScalaVersions.value.last
+ThisBuild / crossScalaVersions := Seq(scala212, scala213, scala3)
+ThisBuild / scalaVersion := scala213
 ThisBuild / githubWorkflowPublishTargetBranches := List()
-ThisBuild / githubWorkflowJavaVersions := List(JavaSpec.temurin("17"))
+ThisBuild / githubWorkflowJavaVersions := List(JavaSpec.temurin("21"))
 ThisBuild / githubWorkflowBuildPreamble ++= List(
   WorkflowStep.Sbt(List("scalafmtCheckAll"), name = Some("Check formatting"))
 )
@@ -44,8 +48,8 @@ lazy val standardSettings = Defaults.coreDefaultSettings ++ Seq(
   ),
   javacOptions ++= Seq("-deprecation", "-Xlint:unchecked"),
   // targets Java 8 bytecode (scalac & javac)
-  ThisBuild / scalacOptions ++= {
-    if (scalaVersion.value.startsWith("2.12")) Seq.empty
+  scalacOptions ++= {
+    if (scalaVersion.value.startsWith("2.12") || scalaVersion.value.startsWith("3")) Seq.empty
     else Seq("-target", "8")
   },
   ThisBuild / javacOptions ++= Seq("-source", "8", "-target", "8"),
@@ -64,7 +68,7 @@ lazy val standardSettings = Defaults.coreDefaultSettings ++ Seq(
 lazy val `sphere-libs` = project
   .in(file("."))
   .settings(standardSettings: _*)
-  .settings(publishArtifact := false, publish := {})
+  .settings(publishArtifact := false, publish := {}, crossScalaVersions := Seq(scala212, scala213))
   .aggregate(
     `sphere-util`,
     `sphere-json`,
@@ -91,6 +95,7 @@ lazy val `sphere-json-derivation` = project
   .in(file("./json/json-derivation"))
   .settings(standardSettings: _*)
   .settings(Fmpp.settings: _*)
+  .settings(crossScalaVersions := Seq(scala212, scala213))
   .dependsOn(`sphere-json-core`)
 
 lazy val `sphere-json` = project
@@ -98,6 +103,7 @@ lazy val `sphere-json` = project
   .settings(standardSettings: _*)
   .settings(homepage := Some(
     url("https://github.com/commercetools/sphere-scala-libs/blob/master/json/README.md")))
+  .settings(crossScalaVersions := Seq(scala212, scala213))
   .dependsOn(`sphere-json-core`, `sphere-json-derivation`)
 
 lazy val `sphere-mongo-core` = project
@@ -109,11 +115,13 @@ lazy val `sphere-mongo-derivation` = project
   .in(file("./mongo/mongo-derivation"))
   .settings(standardSettings: _*)
   .settings(Fmpp.settings: _*)
+  .settings(crossScalaVersions := Seq(scala212, scala213))
   .dependsOn(`sphere-mongo-core`)
 
 lazy val `sphere-mongo-derivation-magnolia` = project
   .in(file("./mongo/mongo-derivation-magnolia"))
   .settings(standardSettings: _*)
+  .settings(crossScalaVersions := Seq(scala212, scala213))
   .dependsOn(`sphere-mongo-core`)
 
 lazy val `sphere-mongo` = project
@@ -121,6 +129,7 @@ lazy val `sphere-mongo` = project
   .settings(standardSettings: _*)
   .settings(homepage := Some(
     url("https://github.com/commercetools/sphere-scala-libs/blob/master/mongo/README.md")))
+  .settings(crossScalaVersions := Seq(scala212, scala213))
   .dependsOn(`sphere-mongo-core`, `sphere-mongo-derivation`)
 
 // benchmarks
@@ -128,5 +137,6 @@ lazy val `sphere-mongo` = project
 lazy val benchmarks = project
   .settings(standardSettings: _*)
   .settings(publishArtifact := false, publish := {})
+  .settings(crossScalaVersions := Seq(scala212, scala213))
   .enablePlugins(JmhPlugin)
   .dependsOn(`sphere-util`, `sphere-json`, `sphere-mongo`)

--- a/json/json-core/src/main/scala/io/sphere/json/FromJSON.scala
+++ b/json/json-core/src/main/scala/io/sphere/json/FromJSON.scala
@@ -263,7 +263,7 @@ object FromJSON extends FromJSONInstances {
             case (preciseAmount, fractionDigits, currencyCode, centAmount) =>
               HighPrecisionMoney
                 .fromPreciseAmount(preciseAmount, fractionDigits, currencyCode, centAmount)
-                .leftMap(_.map(JSONParseError))
+                .leftMap(_.map(JSONParseError.apply))
           }
 
         case _ =>

--- a/mongo/mongo-core/src/main/scala/io/sphere/mongo/format/DefaultMongoFormats.scala
+++ b/mongo/mongo-core/src/main/scala/io/sphere/mongo/format/DefaultMongoFormats.scala
@@ -79,7 +79,7 @@ trait DefaultMongoFormats {
   implicit def vecFormat[@specialized A](implicit f: MongoFormat[A]): MongoFormat[Vector[A]] =
     new MongoFormat[Vector[A]] {
       import scala.collection.JavaConverters._
-      override def toMongoValue(a: Vector[A]) = {
+      override def toMongoValue(a: Vector[A]): BasicBSONList = {
         val m = new BasicBSONList()
         if (a.nonEmpty) m.addAll(a.map(f.toMongoValue(_).asInstanceOf[AnyRef]).asJavaCollection)
         m
@@ -104,7 +104,7 @@ trait DefaultMongoFormats {
   implicit def listFormat[@specialized A](implicit f: MongoFormat[A]): MongoFormat[List[A]] =
     new MongoFormat[List[A]] {
       import scala.collection.JavaConverters._
-      override def toMongoValue(a: List[A]) = {
+      override def toMongoValue(a: List[A]): BasicBSONList = {
         val m = new BasicBSONList()
         if (a.nonEmpty) m.addAll(a.map(f.toMongoValue(_).asInstanceOf[AnyRef]).asJavaCollection)
         m
@@ -129,7 +129,7 @@ trait DefaultMongoFormats {
   implicit def setFormat[@specialized A](implicit f: MongoFormat[A]): MongoFormat[Set[A]] =
     new MongoFormat[Set[A]] {
       import scala.collection.JavaConverters._
-      override def toMongoValue(a: Set[A]) = {
+      override def toMongoValue(a: Set[A]): BasicBSONList = {
         val m = new BasicBSONList()
         if (a.nonEmpty) m.addAll(a.map(f.toMongoValue(_).asInstanceOf[AnyRef]).asJavaCollection)
         m

--- a/mongo/mongo-core/src/test/scala/io/sphere/mongo/format/DefaultMongoFormatsTest.scala
+++ b/mongo/mongo-core/src/test/scala/io/sphere/mongo/format/DefaultMongoFormatsTest.scala
@@ -126,9 +126,10 @@ class DefaultMongoFormatsTest
     }
 
     "support Java Locale" in {
-      Locale.getAvailableLocales.filter(_.toLanguageTag != LangTag.UNDEFINED).foreach { l: Locale =>
-        localeFormat.fromMongoValue(localeFormat.toMongoValue(l)).toLanguageTag must be(
-          l.toLanguageTag)
+      Locale.getAvailableLocales.filter(_.toLanguageTag != LangTag.UNDEFINED).foreach {
+        (l: Locale) =>
+          localeFormat.fromMongoValue(localeFormat.toMongoValue(l)).toLanguageTag must be(
+            l.toLanguageTag)
       }
     }
 

--- a/util/src/main/scala/Money.scala
+++ b/util/src/main/scala/Money.scala
@@ -271,6 +271,8 @@ object Money {
     fromDecimalAmount(amount, currency)(BigDecimal.RoundingMode.UNNECESSARY)
   }
 
+  def apply(centAmount: Long, currency: Currency): Money = new Money(centAmount, currency)
+
   private final val bdOne: BigDecimal = BigDecimal(1)
   final val bdTen: BigDecimal = BigDecimal(10)
 

--- a/util/src/test/scala/HighPrecisionMoneySpec.scala
+++ b/util/src/test/scala/HighPrecisionMoneySpec.scala
@@ -14,7 +14,8 @@ class HighPrecisionMoneySpec extends AnyFunSpec with Matchers with ScalaCheckDri
   import HighPrecisionMoney.ImplicitsString._
   import HighPrecisionMoney.ImplicitsStringPrecise._
 
-  implicit val defaultRoundingMode = BigDecimal.RoundingMode.HALF_EVEN
+  implicit val defaultRoundingMode: BigDecimal.RoundingMode.Value =
+    BigDecimal.RoundingMode.HALF_EVEN
 
   val Euro: Currency = Currency.getInstance("EUR")
 
@@ -198,6 +199,7 @@ class HighPrecisionMoneySpec extends AnyFunSpec with Matchers with ScalaCheckDri
 
     it("should not fail on toString") {
       forAll(DomainObjectsGen.highPrecisionMoney) { m =>
+        println(m.toString)
         m.toString
       }
     }

--- a/util/src/test/scala/HighPrecisionMoneySpec.scala
+++ b/util/src/test/scala/HighPrecisionMoneySpec.scala
@@ -199,7 +199,6 @@ class HighPrecisionMoneySpec extends AnyFunSpec with Matchers with ScalaCheckDri
 
     it("should not fail on toString") {
       forAll(DomainObjectsGen.highPrecisionMoney) { m =>
-        println(m.toString)
         m.toString
       }
     }

--- a/util/src/test/scala/MoneySpec.scala
+++ b/util/src/test/scala/MoneySpec.scala
@@ -10,7 +10,7 @@ class MoneySpec extends AnyFunSpec with Matchers with ScalaCheckDrivenPropertyCh
   import Money.ImplicitsDecimal._
   import Money._
 
-  implicit val mode = BigDecimal.RoundingMode.UNNECESSARY
+  implicit val mode: BigDecimal.RoundingMode.Value = BigDecimal.RoundingMode.UNNECESSARY
 
   def euroCents(cents: Long): Money = EUR(0).withCentAmount(cents)
 


### PR DESCRIPTION
This is a minimalist approach to enable cross-compilation for all non macro projects, most notably `sphere-util`, so they can be used in downstream Scala 3 projects. I haven't touched the more macro heavy `sphere-json-*` and `sphere-mongo-*` submodules.

Running the tests on Scala 3 currently still causes a [test failure](https://github.com/commercetools/sphere-scala-libs/actions/runs/13036209343/job/36367150932#step:8:294):

```
Cause: java.lang.IllegalArgumentException: requirement failed: The scale of the given amount does not match the scale of the provided currency. - 0 <-> 2
```

The issue also occurs on Scala 2 though, it's just not surfaced there in the tests currently perhaps due to some subtle differences in how scalacheck runs. Here's a repro:

```scala

import io.sphere.util.Money
import scala.math.BigDecimal
import java.util.Currency
import scala.jdk.CollectionConverters._

Money(BigDecimal(-9223372036854775808L), Currency.getAvailableCurrencies.asScala.head)
```

Not sure how best to deal with that so I'm asking the domain experts for advice here.