### PR TITLE
Remove the 'logger' val from the Logger trait's namespace

### DIFF
--- a/util/src/main/scala/Logging.scala
+++ b/util/src/main/scala/Logging.scala
@@ -1,5 +1,9 @@
 package io.sphere.util
 
-trait Logging extends com.typesafe.scalalogging.StrictLogging {
-  protected val log = logger
+import com.typesafe.scalalogging.Logger
+import org.slf4j.LoggerFactory
+
+trait Logging {
+  protected val log: Logger =
+    Logger(LoggerFactory.getLogger(getClass.getName))
 }

--- a/util/src/main/scala/Reflect.scala
+++ b/util/src/main/scala/Reflect.scala
@@ -16,8 +16,7 @@ object Reflect extends Logging {
     * other words, the case class constructors should be pure functions.
     */
   val getCaseClassMeta = new Memoizer[Class[_], CaseClassMeta](clazz => {
-    logger.trace(
-      "Initializing reflection metadata for case class or object %s".format(clazz.getName))
+    log.trace("Initializing reflection metadata for case class or object %s".format(clazz.getName))
     CaseClassMeta(getCaseClassFieldMeta(clazz))
   })
 


### PR DESCRIPTION
- Currently log and logger are both visible and are identical.  This is unnecessary and can conflict with other things (io logger) 