### PR TITLE
Add Class[_] -> String subType name getter method

### DIFF
--- a/json/json-core/src/main/scala/io/sphere/json/JSON.scala
+++ b/json/json-core/src/main/scala/io/sphere/json/JSON.scala
@@ -10,6 +10,9 @@ trait JSON[A] extends FromJSON[A] with ToJSON[A] {
   // This field is only used in case we derive a trait, for classes/objects it remains empty
   // It uses the JSON names not the Scala names (if there's @JSONTypeHint renaming a class the renamed name is used here)
   def subTypeNames: List[String] = Nil
+
+  // Serialized type-hint value for a subtype's runtime class; only resolves when deriving a trait/sum
+  def subTypeName(clazz: Class[_]): Option[String] = None
 }
 
 object JSON extends JSONCatsInstances with JSONLowPriorityImplicits {

--- a/json/json-derivation/src/main/scala/io/sphere/json/generic/package.fmpp.scala
+++ b/json/json-derivation/src/main/scala/io/sphere/json/generic/package.fmpp.scala
@@ -416,6 +416,12 @@ package object generic extends Logging {
           .toList
           .distinct
 
+      override def subTypeName(clazz: Class[_]): Option[String] =
+        allSelectors.iterator
+          .filterNot(_.serializer.isInstanceOf[TypeSelectorContainer])
+          .find(_.clazz == clazz)
+          .map(_.typeValue)
+
       def read(jval: JValue): ValidatedNel[JSONError, T] = fromJSON.read(jval)
 
       def write(t: T): JValue = toJSON.write(t)

--- a/json/json-derivation/src/test/scala/io/sphere/json/generic/NestedSubTypeNameSpec.scala
+++ b/json/json-derivation/src/test/scala/io/sphere/json/generic/NestedSubTypeNameSpec.scala
@@ -14,6 +14,14 @@ class NestedSubTypeNameSpec extends AnyWordSpec with Matchers {
     // Should only contain leaf class names, no trait names and no duplicates
     format.subTypeNames must be(List("SubClass1A", "SubClass2A"))
   }
+
+  "resolve only leaf classes to their type-hint values in nested trait hierarchies" in {
+    val format: JSON[SuperType2] =
+      jsonTypeSwitch[SuperType2, SubType1, SubType2](Nil)
+
+    format.subTypeName(classOf[SubType1.SubClass1A]) must be(Some("SubClass1A"))
+    format.subTypeName(classOf[SubType2.SubClass2A]) must be(Some("SubClass2A"))
+  }
 }
 
 object NestedSubTypeNameSpec {

--- a/json/json-derivation/src/test/scala/io/sphere/json/generic/SubTypeNameSpec.scala
+++ b/json/json-derivation/src/test/scala/io/sphere/json/generic/SubTypeNameSpec.scala
@@ -38,8 +38,8 @@ class SubTypeNameSpec extends AnyWordSpec with Matchers {
   "JSON.subTypeName" must {
 
     def check(format: JSON[SuperType]): Unit = {
-      format.subTypeName(classOf[Obj1.type]) must be(Some("Obj1"))
-      format.subTypeName(classOf[ObjHidden.type]) must be(Some("Obj2"))
+      format.subTypeName(Obj1.getClass) must be(Some("Obj1"))
+      format.subTypeName(ObjHidden.getClass) must be(Some("Obj2"))
       format.subTypeName(classOf[Class1]) must be(Some("Class1"))
       format.subTypeName(classOf[ClassHidden]) must be(Some("Class2"))
     }

--- a/json/json-derivation/src/test/scala/io/sphere/json/generic/SubTypeNameSpec.scala
+++ b/json/json-derivation/src/test/scala/io/sphere/json/generic/SubTypeNameSpec.scala
@@ -34,6 +34,34 @@ class SubTypeNameSpec extends AnyWordSpec with Matchers {
         subTypeNames)
     }
   }
+
+  "JSON.subTypeName" must {
+
+    def check(format: JSON[SuperType]): Unit = {
+      format.subTypeName(classOf[Obj1.type]) must be(Some("Obj1"))
+      format.subTypeName(classOf[ObjHidden.type]) must be(Some("Obj2"))
+      format.subTypeName(classOf[Class1]) must be(Some("Class1"))
+      format.subTypeName(classOf[ClassHidden]) must be(Some("Class2"))
+    }
+
+    "resolve each leaf subtype class to its type-hint value when using deriveJSON" in {
+      check(deriveJSON)
+    }
+
+    "resolve each leaf subtype class to its type-hint value when using jsonTypeSwitch" in {
+      implicit val obj1F: JSON[Obj1.type] = deriveJSON
+      implicit val objHF: JSON[ObjHidden.type] = deriveJSON
+      implicit val class1F: JSON[Class1] = deriveJSON
+      implicit val classhF: JSON[ClassHidden] = deriveJSON
+
+      check(jsonTypeSwitch[SuperType, Obj1.type, ObjHidden.type, Class1, ClassHidden](Nil))
+    }
+
+    "return None for a plain case class" in {
+      val format: JSON[Class1] = deriveJSON
+      format.subTypeName(classOf[Class1]) must be(None)
+    }
+  }
 }
 
 object SubTypeNameSpec {


### PR DESCRIPTION
- backport from scala 3 branch
- This is a common interface for the following use case: 
```
def `type`(p: Type1): String =
    Type1.json.typeSelectors
      .find {
        case t if t.clazz == p.getClass => true
        case _ => false
      }
      .map(_.typeValue)
      .getOrElse(throw new IllegalStateException(s"Error message"))
```
`.typeSelectors` is not exposed on Scala3, so we need an alternative for this use case. 
after this it would look like: 

```
def `type`(p: Type1): String =
    Type1.json.typeSelectors
      .subTypeName(p.getName)
      .getOrElse(throw new IllegalStateException(s"Error message"))
```