### PR TITLE
Move to common type switch syntax (scala2, scala3)

### DIFF
--- a/json/json-derivation/src/main/scala/io/sphere/json/generic/JSONMacros.scala
+++ b/json/json-derivation/src/main/scala/io/sphere/json/generic/JSONMacros.scala
@@ -115,19 +115,13 @@ private[generic] object JSONMacros {
             }
         }.toList
 
+        val pkg = reify(io.sphere.json.generic.`package`).tree
+        val subs = idents.tail.map(i => q"$pkg.sub[$i]")
+
         c.Expr[JSON[A]](
           Block(
             instanceDefs,
-            Apply(
-              TypeApply(
-                Select(
-                  reify(io.sphere.json.generic.`package`).tree,
-                  TermName("jsonSingletonEnumSwitch")
-                ),
-                idents
-              ),
-              reify(Nil).tree :: Nil
-            )
+            q"$pkg.jsonSingletonEnumSwitch[${idents.head}](_root_.scala.List(..$subs))"
           )
         )
       }
@@ -259,19 +253,13 @@ private[generic] object JSONMacros {
               }
           }.toList
 
+          val pkg = reify(io.sphere.json.generic.`package`).tree
+          val subs = idents.tail.map(i => q"$pkg.sub[$i]")
+
           c.Expr[JSON[A]](
             Block(
               instanceDefs,
-              Apply(
-                TypeApply(
-                  Select(
-                    reify(io.sphere.json.generic.`package`).tree,
-                    TermName("jsonTypeSwitch")
-                  ),
-                  idents
-                ),
-                reify(Nil).tree :: Nil
-              )
+              q"$pkg.jsonTypeSwitch[${idents.head}](_root_.scala.List(..$subs))"
             )
           )
         }

--- a/json/json-derivation/src/main/scala/io/sphere/json/generic/package.fmpp.scala
+++ b/json/json-derivation/src/main/scala/io/sphere/json/generic/package.fmpp.scala
@@ -217,9 +217,9 @@ package object generic extends Logging {
     *
     * This can be used as an alternative to an enum.
     */
-  def toJsonSingletonEnumSwitch[T: ClassTag, A <: T : ClassTag : ToJSON](selectors: List[TypeSelectorToJSON[_]]): ToJSON[T] with TypeSelectorToJSONContainer = {
-    val inSelectors: List[TypeSelectorToJSON[_]] = typeSelectorToJSON[A]() :: selectors
-    val allSelectors = inSelectors.flatMap(s => s.serializer match {
+  def toJsonSingletonEnumSwitch[T: ClassTag](selectors: List[TypeSelectorToJSON[_]]): ToJSON[T] with TypeSelectorToJSONContainer = {
+    require(selectors.nonEmpty, "toJsonSingletonEnumSwitch needs at least one subtype")
+    val allSelectors = selectors.flatMap(s => s.serializer match {
       case container: TypeSelectorToJSONContainer => container.typeSelectors :+ s
       case _ => s :: Nil
     })
@@ -250,10 +250,10 @@ package object generic extends Logging {
     *
     * This can be used as an alternative to an enum.
     */
-  def fromJsonSingletonEnumSwitch[T: ClassTag, A <: T : ClassTag : FromJSON](selectors: List[TypeSelectorFromJSON[_]]): FromJSON[T] with TypeSelectorFromJSONContainer = {
+  def fromJsonSingletonEnumSwitch[T: ClassTag](selectors: List[TypeSelectorFromJSON[_]]): FromJSON[T] with TypeSelectorFromJSONContainer = {
+    require(selectors.nonEmpty, "fromJsonSingletonEnumSwitch needs at least one subtype")
     val readMapBuilder = Map.newBuilder[String, TypeSelectorFromJSON[_]]
-    val inSelectors: List[TypeSelectorFromJSON[_]] = typeSelectorFromJSON[A]() :: selectors
-    val allSelectors = inSelectors.flatMap(s => s.jsonr match {
+    val allSelectors = selectors.flatMap(s => s.jsonr match {
       case container: TypeSelectorFromJSONContainer => container.typeSelectors :+ s
       case _ => s :: Nil
     })
@@ -283,15 +283,15 @@ package object generic extends Logging {
     *
     * This can be used as an alternative to an enum.
     */
-  def jsonSingletonEnumSwitch[T: ClassTag, A <: T : ClassTag : FromJSON : ToJSON](selectors: List[TypeSelector[_]]): JSON[T] with TypeSelectorContainer = {
-    val inSelectors = typeSelector[A]() :: selectors
-    val allSelectors = inSelectors.flatMap(s => s.serializer match {
+  def jsonSingletonEnumSwitch[T: ClassTag](selectors: List[TypeSelector[_]]): JSON[T] with TypeSelectorContainer = {
+    require(selectors.nonEmpty, "jsonSingletonEnumSwitch needs at least one subtype")
+    val allSelectors = selectors.flatMap(s => s.serializer match {
       case container: TypeSelectorContainer => container.typeSelectors :+ s
       case _ => s :: Nil
     })
 
-    val toJSON = toJsonSingletonEnumSwitch[T, A](selectors)
-    val fromJSON = fromJsonSingletonEnumSwitch[T, A](selectors)
+    val toJSON = toJsonSingletonEnumSwitch[T](selectors)
+    val fromJSON = fromJsonSingletonEnumSwitch[T](selectors)
 
     new JSON[T] with TypeSelectorContainer {
       override def typeSelectors: List[TypeSelector[_]] = allSelectors
@@ -302,30 +302,11 @@ package object generic extends Logging {
     }
   }
 
-  <#list 2..20 as i>
-  <#assign typeParams><#list 1..i-1 as j>A${j}<#if i-1 != j>,</#if></#list></#assign>
-  <#assign implTypeParams><#list 1..i as j>A${j} <: T : ToJSON : ClassTag<#if i !=j>,</#if></#list></#assign>
-  def toJsonSingletonEnumSwitch[T: ClassTag, ${implTypeParams}](selectors: List[TypeSelectorToJSON[_]]): ToJSON[T] with TypeSelectorToJSONContainer = toJsonSingletonEnumSwitch[T, ${typeParams}](typeSelectorToJSON[A${i}]() :: selectors)
-  </#list>
-
-  <#list 2..20 as i>
-  <#assign typeParams><#list 1..i-1 as j>A${j}<#if i-1 != j>,</#if></#list></#assign>
-  <#assign implTypeParams><#list 1..i as j>A${j} <: T : FromJSON : ClassTag<#if i !=j>,</#if></#list></#assign>
-  def fromJsonSingletonEnumSwitch[T: ClassTag, ${implTypeParams}](selectors: List[TypeSelectorFromJSON[_]]): FromJSON[T] with TypeSelectorFromJSONContainer = fromJsonSingletonEnumSwitch[T, ${typeParams}](typeSelectorFromJSON[A${i}]() :: selectors)
-  </#list>
-
-  <#list 2..20 as i>
-  <#assign typeParams><#list 1..i-1 as j>A${j}<#if i-1 != j>,</#if></#list></#assign>
-  <#assign implTypeParams><#list 1..i as j>A${j} <: T : FromJSON : ToJSON : ClassTag<#if i !=j>,</#if></#list></#assign>
-  def jsonSingletonEnumSwitch[T: ClassTag, ${implTypeParams}](selectors: List[TypeSelector[_]]): JSON[T] with TypeSelectorContainer = jsonSingletonEnumSwitch[T, ${typeParams}](typeSelector[A${i}]() :: selectors)
-  </#list>
-
-  /** Creates a `ToJSON[T]` instance for some supertype `T`. The instance acts as a type-switch
-    * for the subtypes `A1` and `A2`, delegating to their respective JSON instances based
-    * on a field that acts as a type hint. */
-  def toJsonTypeSwitch[T: ClassTag, A1 <: T: ClassTag: ToJSON, A2 <: T: ClassTag: ToJSON](selectors: List[TypeSelectorToJSON[_]]): ToJSON[T] with TypeSelectorToJSONContainer = {
-    val inSelectors = typeSelectorToJSON[A1]() :: typeSelectorToJSON[A2]() :: selectors
-    val allSelectors = inSelectors.flatMap(s => s.serializer match {
+  /** Creates a `ToJSON[T]` that switches on a type-hint field, delegating to the given subtype
+    * selectors' instances. */
+  def toJsonTypeSwitch[T: ClassTag](selectors: List[TypeSelectorToJSON[_]]): ToJSON[T] with TypeSelectorToJSONContainer = {
+    require(selectors.nonEmpty, "toJsonTypeSwitch needs at least one subtype")
+    val allSelectors = selectors.flatMap(s => s.serializer match {
       case container: TypeSelectorToJSONContainer => container.typeSelectors :+ s
       case _ => s :: Nil
     })
@@ -338,14 +319,17 @@ package object generic extends Logging {
 
     val writeMap = writeMapBuilder.result()
 
+    // Always from the top-level type, so that it matches what fromJsonTypeSwitch reads.
+    val typeField = typeFieldOf(classTag[T].runtimeClass)
+
     new ToJSON[T] with TypeSelectorToJSONContainer {
       override def typeSelectors: List[TypeSelectorToJSON[_]] = allSelectors
 
       def write(t: T): JValue = writeMap.get(t.getClass) match {
         case Some(ts) =>
           ts.write(t) match {
-            case o @ JObject(obj) if obj.exists(_._1 == ts.typeField) => o
-            case j: JObject => j ~ JField(ts.typeField, JString(ts.typeValue))
+            case o @ JObject(obj) if obj.exists(_._1 == typeField) => o
+            case j: JObject => j ~ JField(typeField, JString(ts.typeValue))
             case j => throw new IllegalStateException("The json is not an object but a " + j.getClass)
           }
 
@@ -354,12 +338,11 @@ package object generic extends Logging {
     }
   }
 
-  /** Creates a `FromJSON[T]` instance for some supertype `T`. The instance acts as a type-switch
-    * for the subtypes `A1` and `A2`, delegating to their respective JSON instances based
-    * on a field that acts as a type hint. */
-  def fromJsonTypeSwitch[T: ClassTag, A1 <: T: ClassTag: FromJSON, A2 <: T: ClassTag: FromJSON](selectors: List[TypeSelectorFromJSON[_]]): FromJSON[T] with TypeSelectorFromJSONContainer = {
-    val inSelectors = typeSelectorFromJSON[A1]() :: typeSelectorFromJSON[A2]() :: selectors
-    val allSelectors = inSelectors.flatMap(s => s.jsonr match {
+  /** Creates a `FromJSON[T]` that switches on a type-hint field, delegating to the given subtype
+    * selectors' instances. */
+  def fromJsonTypeSwitch[T: ClassTag](selectors: List[TypeSelectorFromJSON[_]]): FromJSON[T] with TypeSelectorFromJSONContainer = {
+    require(selectors.nonEmpty, "fromJsonTypeSwitch needs at least one subtype")
+    val allSelectors = selectors.flatMap(s => s.jsonr match {
       case container: TypeSelectorFromJSONContainer => container.typeSelectors :+ s
       case _ => s :: Nil
     })
@@ -371,10 +354,7 @@ package object generic extends Logging {
     }
 
     val readMap = readMapBuilder.result()
-    val clazz = classTag[T].runtimeClass
-
-    val fieldWithJSONTypeHint = clazz.getAnnotation(classOf[JSONTypeHintField])
-    val typeField = if (fieldWithJSONTypeHint != null) fieldWithJSONTypeHint.value() else defaultTypeFieldName
+    val typeField = typeFieldOf(classTag[T].runtimeClass)
 
     new FromJSON[T] with TypeSelectorFromJSONContainer {
       override def typeSelectors: List[TypeSelectorFromJSON[_]] = allSelectors
@@ -393,18 +373,17 @@ package object generic extends Logging {
     }
   }
 
-  /** Creates a `JSON[T]` instance for some supertype `T`. The instance acts as a type-switch
-    * for the subtypes `A1` and `A2`, delegating to their respective JSON instances based
-    * on a field that acts as a type hint. */
-  def jsonTypeSwitch[T: ClassTag, A1 <: T: ClassTag: FromJSON: ToJSON, A2 <: T: ClassTag: FromJSON: ToJSON](selectors: List[TypeSelector[_]]): JSON[T] with TypeSelectorContainer = {
-    val inSelectors = typeSelector[A1]() :: typeSelector[A2]() :: selectors
-    val allSelectors = inSelectors.flatMap(s => s.serializer match {
+  /** Creates a `JSON[T]` that switches on a type-hint field, delegating to the given subtype
+    * selectors' instances. */
+  def jsonTypeSwitch[T: ClassTag](selectors: List[TypeSelector[_]]): JSON[T] with TypeSelectorContainer = {
+    require(selectors.nonEmpty, "jsonTypeSwitch needs at least one subtype")
+    val allSelectors = selectors.flatMap(s => s.serializer match {
       case container: TypeSelectorContainer => container.typeSelectors :+ s
       case _ => s :: Nil
     })
 
-    val toJSON = toJsonTypeSwitch[T, A1, A2](selectors)
-    val fromJSON = fromJsonTypeSwitch[T, A1, A2](selectors)
+    val toJSON = toJsonTypeSwitch[T](selectors)
+    val fromJSON = fromJsonTypeSwitch[T](selectors)
 
     new JSON[T] with TypeSelectorContainer {
       override def typeSelectors: List[TypeSelector[_]] = allSelectors
@@ -428,28 +407,6 @@ package object generic extends Logging {
     }
   }
 
-  // special case with only one sub-type
-  def jsonTypeSwitch[T: ClassTag, A1 <: T: ClassTag: FromJSON: ToJSON](selectors: List[TypeSelector[_]]): JSON[T] with TypeSelectorContainer =
-    jsonTypeSwitch[T, A1, A1](selectors)
-
-  <#list 3..126 as i>
-  <#assign typeParams><#list 1..i-1 as j>A${j}<#if i-1 != j>,</#if></#list></#assign>
-  <#assign implTypeParams><#list 1..i as j>A${j} <: T : ToJSON : ClassTag<#if i !=j>,</#if></#list></#assign>
-  def toJsonTypeSwitch[T: ClassTag, ${implTypeParams}](selectors: List[TypeSelectorToJSON[_]]): ToJSON[T] with TypeSelectorToJSONContainer = toJsonTypeSwitch[T, ${typeParams}](typeSelectorToJSON[A${i}]() :: selectors)
-  </#list>
-
-  <#list 3..126 as i>
-  <#assign typeParams><#list 1..i-1 as j>A${j}<#if i-1 != j>,</#if></#list></#assign>
-  <#assign implTypeParams><#list 1..i as j>A${j} <: T : FromJSON : ClassTag<#if i !=j>,</#if></#list></#assign>
-  def fromJsonTypeSwitch[T: ClassTag, ${implTypeParams}](selectors: List[TypeSelectorFromJSON[_]]): FromJSON[T] with TypeSelectorFromJSONContainer = fromJsonTypeSwitch[T, ${typeParams}](typeSelectorFromJSON[A${i}]() :: selectors)
-  </#list>
-
-  <#list 3..126 as i>
-  <#assign typeParams><#list 1..i-1 as j>A${j}<#if i-1 != j>,</#if></#list></#assign>
-  <#assign implTypeParams><#list 1..i as j>A${j} <: T : JSON : ClassTag<#if i !=j>,</#if></#list></#assign>
-  def jsonTypeSwitch[T: ClassTag, ${implTypeParams}](selectors: List[TypeSelector[_]]): JSON[T] with TypeSelectorContainer = jsonTypeSwitch[T, ${typeParams}](typeSelector[A${i}]() :: selectors)
-  </#list>
-
   trait TypeSelectorBase {
     def typeField: String
     def typeValue: String
@@ -469,7 +426,8 @@ package object generic extends Logging {
     def write(a: Any): JValue = toJValue(a.asInstanceOf[A])
   }
 
-  private def typeSelectorToJSON[A: ClassTag: ToJSON](): TypeSelectorToJSON[_] = {
+  /** Builds the write-side selector for the subtype `A` of a `toJsonTypeSwitch`. */
+  def subTo[A: ClassTag: ToJSON]: TypeSelectorToJSON[A] = {
     val clazz = classTag[A].runtimeClass
     val (typeField, typeValue) = getJSONClass(clazz).typeHint match {
       case Some(hint) => (hint.field, hint.value)
@@ -491,7 +449,8 @@ package object generic extends Logging {
     def read(o: JValue): ValidatedNel[JSONError, A] = fromJValue[A](o)
   }
 
-  private def typeSelectorFromJSON[A: ClassTag: FromJSON](): TypeSelectorFromJSON[_] = {
+  /** Builds the read-side selector for the subtype `A` of a `fromJsonTypeSwitch`. */
+  def subFrom[A: ClassTag: FromJSON]: TypeSelectorFromJSON[A] = {
     val clazz = classTag[A].runtimeClass
     val (typeField, typeValue) = getJSONClass(clazz).typeHint match {
       case Some(hint) => (hint.field, hint.value)
@@ -512,7 +471,8 @@ package object generic extends Logging {
     def write(a: Any): JValue = toJValue(a.asInstanceOf[A])
   }
 
-  private def typeSelector[A: ClassTag: FromJSON: ToJSON](): TypeSelector[_] = {
+  /** Builds the selector for the subtype `A` of a `jsonTypeSwitch`. */
+  def sub[A: ClassTag: FromJSON: ToJSON]: TypeSelector[A] = {
     val clazz = classTag[A].runtimeClass
     val (typeField, typeValue) = getJSONClass(clazz).typeHint match {
       case Some(hint) => (hint.field, hint.value)
@@ -523,6 +483,11 @@ package object generic extends Logging {
 
   private def defaultTypeValue(clazz: Class[_]): String =
     clazz.getSimpleName.replace("$", "")
+
+  private def typeFieldOf(clazz: Class[_]): String = {
+    val fieldWithJSONTypeHint = clazz.getAnnotation(classOf[JSONTypeHintField])
+    if (fieldWithJSONTypeHint != null) fieldWithJSONTypeHint.value() else defaultTypeFieldName
+  }
 
   private def findTypeValue(o: JObject, typeField: String): Option[String] =
     o.obj.find(_._1 == typeField).flatMap(_._2.extractOpt[String])

--- a/json/json-derivation/src/main/scala/io/sphere/json/generic/package.fmpp.scala
+++ b/json/json-derivation/src/main/scala/io/sphere/json/generic/package.fmpp.scala
@@ -72,10 +72,7 @@ package object generic extends Logging {
     * representations of the enumeration values. */
   def jsonEnum(e: Enumeration): JSON[e.Value] = JSONofToAndFrom(toJsonEnum(e), fromJsonEnum(e))
 
-  private def jsonSingletonTypeValue[T](singleton: T): String = {
-    val clazz = singleton.getClass
-    getJSONClass(clazz).typeHint.fold(defaultTypeValue(clazz))(_.value)
-  }
+  private def jsonSingletonTypeValue[T](singleton: T): String = typeValueOf(singleton.getClass)
 
   /** Creates a ToJSON instance for a singleton object that encodes only the type value
     * as a JSON string. */
@@ -408,7 +405,6 @@ package object generic extends Logging {
   }
 
   trait TypeSelectorBase {
-    def typeField: String
     def typeValue: String
     def clazz: Class[_]
   }
@@ -422,18 +418,14 @@ package object generic extends Logging {
     def serializer: ToJSON[A]
   }
 
-  final class TypeSelectorToJSONImpl[A] private[generic](val typeField: String, val typeValue: String, val clazz: Class[_])(implicit val serializer: ToJSON[A]) extends TypeSelectorToJSON[A] {
+  final class TypeSelectorToJSONImpl[A] private[generic](val typeValue: String, val clazz: Class[_])(implicit val serializer: ToJSON[A]) extends TypeSelectorToJSON[A] {
     def write(a: Any): JValue = toJValue(a.asInstanceOf[A])
   }
 
   /** Builds the write-side selector for the subtype `A` of a `toJsonTypeSwitch`. */
   def subTo[A: ClassTag: ToJSON]: TypeSelectorToJSON[A] = {
     val clazz = classTag[A].runtimeClass
-    val (typeField, typeValue) = getJSONClass(clazz).typeHint match {
-      case Some(hint) => (hint.field, hint.value)
-      case None => (defaultTypeFieldName, defaultTypeValue(clazz))
-    }
-    new TypeSelectorToJSONImpl[A](typeField, typeValue, clazz)
+    new TypeSelectorToJSONImpl[A](typeValueOf(clazz), clazz)
   }
 
   trait TypeSelectorFromJSONContainer {
@@ -445,25 +437,21 @@ package object generic extends Logging {
     def jsonr: FromJSON[A]
   }
 
-  final class TypeSelectorFromJSONImpl[A] private[generic](val typeField: String, val typeValue: String, val clazz: Class[_])(implicit val jsonr: FromJSON[A]) extends TypeSelectorFromJSON[A] {
+  final class TypeSelectorFromJSONImpl[A] private[generic](val typeValue: String, val clazz: Class[_])(implicit val jsonr: FromJSON[A]) extends TypeSelectorFromJSON[A] {
     def read(o: JValue): ValidatedNel[JSONError, A] = fromJValue[A](o)
   }
 
   /** Builds the read-side selector for the subtype `A` of a `fromJsonTypeSwitch`. */
   def subFrom[A: ClassTag: FromJSON]: TypeSelectorFromJSON[A] = {
     val clazz = classTag[A].runtimeClass
-    val (typeField, typeValue) = getJSONClass(clazz).typeHint match {
-      case Some(hint) => (hint.field, hint.value)
-      case None => (defaultTypeFieldName, defaultTypeValue(clazz))
-    }
-    new TypeSelectorFromJSONImpl[A](typeField, typeValue, clazz)
+    new TypeSelectorFromJSONImpl[A](typeValueOf(clazz), clazz)
   }
 
   trait TypeSelectorContainer extends TypeSelectorFromJSONContainer with TypeSelectorToJSONContainer {
     def typeSelectors: List[TypeSelector[_]]
   }
 
-  final class TypeSelector[A] private[generic](val typeField: String, val typeValue: String, val clazz: Class[_])
+  final class TypeSelector[A] private[generic](val typeValue: String, val clazz: Class[_])
                                               (implicit val jsonr: FromJSON[A], val serializer: ToJSON[A])
     extends TypeSelectorFromJSON[A] with TypeSelectorToJSON[A] {
 
@@ -474,15 +462,14 @@ package object generic extends Logging {
   /** Builds the selector for the subtype `A` of a `jsonTypeSwitch`. */
   def sub[A: ClassTag: FromJSON: ToJSON]: TypeSelector[A] = {
     val clazz = classTag[A].runtimeClass
-    val (typeField, typeValue) = getJSONClass(clazz).typeHint match {
-      case Some(hint) => (hint.field, hint.value)
-      case None => (defaultTypeFieldName, defaultTypeValue(clazz))
-    }
-    new TypeSelector[A](typeField, typeValue, clazz)
+    new TypeSelector[A](typeValueOf(clazz), clazz)
   }
 
   private def defaultTypeValue(clazz: Class[_]): String =
     clazz.getSimpleName.replace("$", "")
+
+  private def typeValueOf(clazz: Class[_]): String =
+    getJSONClass(clazz).typeHint.fold(defaultTypeValue(clazz))(_.value)
 
   private def typeFieldOf(clazz: Class[_]): String = {
     val fieldWithJSONTypeHint = clazz.getAnnotation(classOf[JSONTypeHintField])

--- a/json/json-derivation/src/test/scala/io/sphere/json/JSONSingletonSpec.scala
+++ b/json/json-derivation/src/test/scala/io/sphere/json/JSONSingletonSpec.scala
@@ -30,15 +30,15 @@ class JSONSingletonSpec extends AnyFunSpec with Matchers {
     implicit val toSingleBJSON: ToJSON[SingletonB.type] = toJsonSingleton(SingletonB)
     implicit val toSingleCJSON: ToJSON[SingletonC.type] = toJsonSingleton(SingletonC)
     implicit val toSingleEnumJSON: ToJSON[SingletonEnum] =
-      toJsonSingletonEnumSwitch[SingletonEnum, SingletonA.type, SingletonB.type, SingletonC.type](
-        Nil)
+      toJsonSingletonEnumSwitch[SingletonEnum](
+        List(subTo[SingletonA.type], subTo[SingletonB.type], subTo[SingletonC.type]))
     // FromJSON
     implicit val fromSingleAJSON: FromJSON[SingletonA.type] = fromJsonSingleton(SingletonA)
     implicit val fromSingleBJSON: FromJSON[SingletonB.type] = fromJsonSingleton(SingletonB)
     implicit val fromSingleCJSON: FromJSON[SingletonC.type] = fromJsonSingleton(SingletonC)
     implicit val fromSingleEnumJSON: FromJSON[SingletonEnum] =
-      fromJsonSingletonEnumSwitch[SingletonEnum, SingletonA.type, SingletonB.type, SingletonC.type](
-        Nil)
+      fromJsonSingletonEnumSwitch[SingletonEnum](
+        List(subFrom[SingletonA.type], subFrom[SingletonB.type], subFrom[SingletonC.type]))
 
     List(SingletonA, SingletonB, SingletonC).foreach { s: SingletonEnum =>
       fromJSON[SingletonEnum](toJSON(s)) must equal(Valid(s))

--- a/json/json-derivation/src/test/scala/io/sphere/json/JSONSpec.scala
+++ b/json/json-derivation/src/test/scala/io/sphere/json/JSONSpec.scala
@@ -237,13 +237,14 @@ class JSONSpec extends AnyFunSpec with Matchers {
       implicit val birdToJSON: ToJSON[Bird] = deriveToJSON
       implicit val dogToJSON: ToJSON[Dog] = deriveToJSON
       implicit val catToJSON: ToJSON[Cat] = deriveToJSON
-      implicit val animalToJSON: ToJSON[Animal] = toJsonTypeSwitch[Animal, Bird, Dog, Cat](Nil)
+      implicit val animalToJSON: ToJSON[Animal] =
+        toJsonTypeSwitch[Animal](List(subTo[Bird], subTo[Dog], subTo[Cat]))
       // FromJSON
       implicit val birdFromJSON: FromJSON[Bird] = deriveFromJSON
       implicit val dogFromJSON: FromJSON[Dog] = deriveFromJSON
       implicit val catFromJSON: FromJSON[Cat] = deriveFromJSON
       implicit val animalFromJSON: FromJSON[Animal] =
-        fromJsonTypeSwitch[Animal, Bird, Dog, Cat](Nil)
+        fromJsonTypeSwitch[Animal](List(subFrom[Bird], subFrom[Dog], subFrom[Cat]))
 
       List[Animal](Bird("Peewee"), Dog("Hasso"), Cat("Felidae")).foreach { a =>
         fromJSON[Animal](toJSON(a)) must equal(Valid(a))
@@ -262,12 +263,12 @@ class JSONSpec extends AnyFunSpec with Matchers {
       implicit val toSingleJSON: ToJSON[JSONSpec.SingletonMixed.type] = deriveToJSON
       implicit val toRecordJSON: ToJSON[RecordMixed] = deriveToJSON
       implicit val toMixedJSON: ToJSON[Mixed] =
-        toJsonTypeSwitch[Mixed, SingletonMixed.type, RecordMixed](Nil)
+        toJsonTypeSwitch[Mixed](List(subTo[SingletonMixed.type], subTo[RecordMixed]))
       // FromJSON
       implicit val fromSingleJSON: FromJSON[JSONSpec.SingletonMixed.type] = deriveFromJSON
       implicit val fromRecordJSON: FromJSON[RecordMixed] = deriveFromJSON
       implicit val fromMixedJSON: FromJSON[Mixed] =
-        fromJsonTypeSwitch[Mixed, SingletonMixed.type, RecordMixed](Nil)
+        fromJsonTypeSwitch[Mixed](List(subFrom[SingletonMixed.type], subFrom[RecordMixed]))
       List[Mixed](SingletonMixed, RecordMixed(1)).foreach { m =>
         fromJSON[Mixed](toJSON(m)) must equal(Valid(m))
       }
@@ -291,11 +292,14 @@ class JSONSpec extends AnyFunSpec with Matchers {
       implicit val to3: ToJSON[TestSubjectConcrete3] = deriveToJSON
       implicit val to4: ToJSON[TestSubjectConcrete4] = deriveToJSON
       implicit val toA: ToJSON[TestSubjectCategoryA] =
-        toJsonTypeSwitch[TestSubjectCategoryA, TestSubjectConcrete1, TestSubjectConcrete2](Nil)
+        toJsonTypeSwitch[TestSubjectCategoryA](
+          List(subTo[TestSubjectConcrete1], subTo[TestSubjectConcrete2]))
       implicit val toB: ToJSON[TestSubjectCategoryB] =
-        toJsonTypeSwitch[TestSubjectCategoryB, TestSubjectConcrete3, TestSubjectConcrete4](Nil)
+        toJsonTypeSwitch[TestSubjectCategoryB](
+          List(subTo[TestSubjectConcrete3], subTo[TestSubjectConcrete4]))
       implicit val toBase: ToJSON[TestSubjectBase] =
-        toJsonTypeSwitch[TestSubjectBase, TestSubjectCategoryA, TestSubjectCategoryB](Nil)
+        toJsonTypeSwitch[TestSubjectBase](
+          List(subTo[TestSubjectCategoryA], subTo[TestSubjectCategoryB]))
 
       // FromJSON
       implicit val from1: FromJSON[TestSubjectConcrete1] = deriveFromJSON
@@ -303,11 +307,14 @@ class JSONSpec extends AnyFunSpec with Matchers {
       implicit val from3: FromJSON[TestSubjectConcrete3] = deriveFromJSON
       implicit val from4: FromJSON[TestSubjectConcrete4] = deriveFromJSON
       implicit val fromA: FromJSON[TestSubjectCategoryA] =
-        fromJsonTypeSwitch[TestSubjectCategoryA, TestSubjectConcrete1, TestSubjectConcrete2](Nil)
+        fromJsonTypeSwitch[TestSubjectCategoryA](
+          List(subFrom[TestSubjectConcrete1], subFrom[TestSubjectConcrete2]))
       implicit val fromB: FromJSON[TestSubjectCategoryB] =
-        fromJsonTypeSwitch[TestSubjectCategoryB, TestSubjectConcrete3, TestSubjectConcrete4](Nil)
+        fromJsonTypeSwitch[TestSubjectCategoryB](
+          List(subFrom[TestSubjectConcrete3], subFrom[TestSubjectConcrete4]))
       implicit val fromBase: FromJSON[TestSubjectBase] =
-        fromJsonTypeSwitch[TestSubjectBase, TestSubjectCategoryA, TestSubjectCategoryB](Nil)
+        fromJsonTypeSwitch[TestSubjectBase](
+          List(subFrom[TestSubjectCategoryA], subFrom[TestSubjectCategoryB]))
 
       val testSubjects = List[TestSubjectBase](
         TestSubjectConcrete1("testSubject1"),
@@ -366,6 +373,6 @@ object TestSubjectBase {
     implicit val jsonA: JSON[TestSubjectCategoryA] = TestSubjectCategoryA.json
     implicit val jsonB: JSON[TestSubjectCategoryB] = TestSubjectCategoryB.json
 
-    jsonTypeSwitch[TestSubjectBase, TestSubjectCategoryA, TestSubjectCategoryB](Nil)
+    jsonTypeSwitch[TestSubjectBase](List(sub[TestSubjectCategoryA], sub[TestSubjectCategoryB]))
   }
 }

--- a/json/json-derivation/src/test/scala/io/sphere/json/TypeSelectorContainerSpec.scala
+++ b/json/json-derivation/src/test/scala/io/sphere/json/TypeSelectorContainerSpec.scala
@@ -1,6 +1,6 @@
 package io.sphere.json
 
-import io.sphere.json.generic.{TypeSelectorContainer, deriveJSON, jsonTypeSwitch}
+import io.sphere.json.generic.{TypeSelectorContainer, deriveJSON, jsonTypeSwitch, sub}
 import org.scalatest.matchers.must.Matchers
 import org.scalatest.wordspec.AnyWordSpec
 
@@ -43,7 +43,7 @@ object TypeSelectorContainerSpec {
     // ex if we define TypeA.Class1 && TypeB.Class1
     // as both will use the same type value discriminator
     implicit val json: JSON[Message] with TypeSelectorContainer =
-      jsonTypeSwitch[Message, TypeA, TypeB](Nil)
+      jsonTypeSwitch[Message](List(sub[TypeA], sub[TypeB]))
   }
 
   sealed trait TypeA extends Message

--- a/json/json-derivation/src/test/scala/io/sphere/json/TypeSelectorContainerSpec.scala
+++ b/json/json-derivation/src/test/scala/io/sphere/json/TypeSelectorContainerSpec.scala
@@ -18,10 +18,6 @@ class TypeSelectorContainerSpec extends AnyWordSpec with Matchers {
         "ClassB2",
         "TypeB")
 
-      // I don't think it's useful to allow different type fields. How is it possible to deserialize one json
-      // if different type fields are used?
-      selectors.map(_.typeField) must be(List("type", "type", "type", "type", "type", "type"))
-
       selectors.map(_.clazz.getName) must contain.allOf(
         "io.sphere.json.TypeSelectorContainerSpec$TypeA$ClassA1",
         "io.sphere.json.TypeSelectorContainerSpec$TypeA$ClassA2",

--- a/json/json-derivation/src/test/scala/io/sphere/json/generic/JsonTypeSwitchSpec.scala
+++ b/json/json-derivation/src/test/scala/io/sphere/json/generic/JsonTypeSwitchSpec.scala
@@ -10,28 +10,28 @@ class JsonTypeSwitchSpec extends AnyWordSpec with Matchers with JsonTypeSwitchSp
   "jsonTypeSwitch" must {
 
     "derive a subset of a sealed trait" in {
-      val format: JSON[A] = jsonTypeSwitch[A, B, C](Nil)
+      val format: JSON[A] = jsonTypeSwitch[A](List(sub[B], sub[C]))
       testDeriveASubsetOfASealedTrait(format)
     }
 
     "return an invalid result on malformed sum-type JSON" in {
-      val format: JSON[A] = jsonTypeSwitch[A, B, C](Nil)
+      val format: JSON[A] = jsonTypeSwitch[A](List(sub[B], sub[C]))
       testMalformedSumTypeJson(format)
     }
 
     "derive a subset of a sealed trait with a mongoKey" in {
-      val format: JSON[A] = jsonTypeSwitch[A, B, D](Nil)
+      val format: JSON[A] = jsonTypeSwitch[A](List(sub[B], sub[D]))
       testDeriveSubsetWithMongoKey(format)
     }
 
     "combine different sum types tree" in {
-      val format: JSON[Message] = jsonTypeSwitch[Message, TypeA, TypeB](Nil)
+      val format: JSON[Message] = jsonTypeSwitch[Message](List(sub[TypeA], sub[TypeB]))
       testCombineSumTypes(format)
     }
 
     "handle custom implementations for subtypes" in {
       implicit val jsonB: JSON[B] = customJsonB
-      val format: JSON[A] = jsonTypeSwitch[A, B, D, C](Nil)
+      val format: JSON[A] = jsonTypeSwitch[A](List(sub[B], sub[D], sub[C]))
       testCustomSubtypeImpl(format)
     }
 

--- a/json/json-derivation/src/test/scala/io/sphere/json/generic/JsonTypeSwitchSpecCommon.scala
+++ b/json/json-derivation/src/test/scala/io/sphere/json/generic/JsonTypeSwitchSpecCommon.scala
@@ -75,11 +75,11 @@ trait JsonTypeSwitchSpecCommon { self: AnyWordSpec with Matchers =>
   }
 
   def testPlatformFormattedNotificationCase(): Unit = {
-    val formatSub2 = jsonTypeSwitch[SubTrait2, SubTrait2.O3.type, SubTrait2.O4.type](Nil)
-    val formatSub3 = jsonTypeSwitch[SubTrait3, SubTrait3.O5.type, SubTrait3.O6.type](Nil)
+    val formatSub2 = jsonTypeSwitch[SubTrait2](List(sub[SubTrait2.O3.type], sub[SubTrait2.O4.type]))
+    val formatSub3 = jsonTypeSwitch[SubTrait3](List(sub[SubTrait3.O5.type], sub[SubTrait3.O6.type]))
 
     val typeSelectors = formatSub2.typeSelectors ++ formatSub3.typeSelectors
-    val formatSuper: JSON[SuperTrait] = jsonTypeSwitch[SuperTrait, SubTrait1](typeSelectors)
+    val formatSuper: JSON[SuperTrait] = jsonTypeSwitch[SuperTrait](sub[SubTrait1] :: typeSelectors)
 
     val objs =
       List[SuperTrait](

--- a/json/json-derivation/src/test/scala/io/sphere/json/generic/NestedSubTypeNameSpec.scala
+++ b/json/json-derivation/src/test/scala/io/sphere/json/generic/NestedSubTypeNameSpec.scala
@@ -9,7 +9,7 @@ class NestedSubTypeNameSpec extends AnyWordSpec with Matchers {
 
   "return only leaf class names in nested trait hierarchies" in {
     val format: JSON[SuperType2] =
-      jsonTypeSwitch[SuperType2, SubType1, SubType2](Nil)
+      jsonTypeSwitch[SuperType2](List(sub[SubType1], sub[SubType2]))
 
     // Should only contain leaf class names, no trait names and no duplicates
     format.subTypeNames must be(List("SubClass1A", "SubClass2A"))
@@ -17,7 +17,7 @@ class NestedSubTypeNameSpec extends AnyWordSpec with Matchers {
 
   "resolve only leaf classes to their type-hint values in nested trait hierarchies" in {
     val format: JSON[SuperType2] =
-      jsonTypeSwitch[SuperType2, SubType1, SubType2](Nil)
+      jsonTypeSwitch[SuperType2](List(sub[SubType1], sub[SubType2]))
 
     format.subTypeName(classOf[SubType1.SubClass1A]) must be(Some("SubClass1A"))
     format.subTypeName(classOf[SubType2.SubClass2A]) must be(Some("SubClass2A"))

--- a/json/json-derivation/src/test/scala/io/sphere/json/generic/SubTypeNameSpec.scala
+++ b/json/json-derivation/src/test/scala/io/sphere/json/generic/SubTypeNameSpec.scala
@@ -26,7 +26,8 @@ class SubTypeNameSpec extends AnyWordSpec with Matchers {
       implicit val classhF: JSON[ClassHidden] = deriveJSON
 
       val format: JSON[SuperType] =
-        jsonTypeSwitch[SuperType, Obj1.type, ObjHidden.type, Class1, ClassHidden](Nil)
+        jsonTypeSwitch[SuperType](
+          List(sub[Obj1.type], sub[ObjHidden.type], sub[Class1], sub[ClassHidden]))
 
       format.subTypeNames must be(subTypeNames)
 
@@ -54,7 +55,9 @@ class SubTypeNameSpec extends AnyWordSpec with Matchers {
       implicit val class1F: JSON[Class1] = deriveJSON
       implicit val classhF: JSON[ClassHidden] = deriveJSON
 
-      check(jsonTypeSwitch[SuperType, Obj1.type, ObjHidden.type, Class1, ClassHidden](Nil))
+      check(
+        jsonTypeSwitch[SuperType](
+          List(sub[Obj1.type], sub[ObjHidden.type], sub[Class1], sub[ClassHidden])))
     }
 
     "return None for a plain case class" in {

--- a/json/json-derivation/src/test/scala/io/sphere/json/generic/WideTypeSwitchSpec.scala
+++ b/json/json-derivation/src/test/scala/io/sphere/json/generic/WideTypeSwitchSpec.scala
@@ -1,0 +1,841 @@
+package io.sphere.json.generic
+
+import io.sphere.json.JSON
+import io.sphere.util.test._
+import org.scalatest.matchers.must.Matchers
+import org.scalatest.wordspec.AnyWordSpec
+
+/** A sealed trait far wider than either version used to support: Scala 2 was capped at ~125
+  * subtypes by the JVM method-parameter limit, Scala 3 at ~25 by `-Xmax-inlines` and then at ~52 by
+  * the JVM's 64KB method limit. If any of those ceilings comes back, this stops compiling.
+  *
+  * Each subtype's instance lives in its own companion, so the derivations land in 200 tiny class
+  * initialisers instead of one huge one.
+  */
+class WideTypeSwitchSpec extends AnyWordSpec with Matchers {
+  import WideTypeSwitchSpec._
+
+  "jsonTypeSwitch" must {
+    "handle 200 subtypes" in {
+      json.subTypeNames.size must be(200)
+      json.subTypeNames.distinct.size must be(200)
+
+      values.size must be(200)
+      values.foreach(value => json.read(json.write(value)).expectValid must be(value))
+    }
+  }
+}
+
+object WideTypeSwitchSpec {
+  sealed trait Wide
+
+  // format: off
+  case class C1(x: Int) extends Wide
+  object C1 { implicit val json: JSON[C1] = deriveJSON[C1] }
+  case class C2(x: Int) extends Wide
+  object C2 { implicit val json: JSON[C2] = deriveJSON[C2] }
+  case class C3(x: Int) extends Wide
+  object C3 { implicit val json: JSON[C3] = deriveJSON[C3] }
+  case class C4(x: Int) extends Wide
+  object C4 { implicit val json: JSON[C4] = deriveJSON[C4] }
+  case class C5(x: Int) extends Wide
+  object C5 { implicit val json: JSON[C5] = deriveJSON[C5] }
+  case class C6(x: Int) extends Wide
+  object C6 { implicit val json: JSON[C6] = deriveJSON[C6] }
+  case class C7(x: Int) extends Wide
+  object C7 { implicit val json: JSON[C7] = deriveJSON[C7] }
+  case class C8(x: Int) extends Wide
+  object C8 { implicit val json: JSON[C8] = deriveJSON[C8] }
+  case class C9(x: Int) extends Wide
+  object C9 { implicit val json: JSON[C9] = deriveJSON[C9] }
+  case class C10(x: Int) extends Wide
+  object C10 { implicit val json: JSON[C10] = deriveJSON[C10] }
+  case class C11(x: Int) extends Wide
+  object C11 { implicit val json: JSON[C11] = deriveJSON[C11] }
+  case class C12(x: Int) extends Wide
+  object C12 { implicit val json: JSON[C12] = deriveJSON[C12] }
+  case class C13(x: Int) extends Wide
+  object C13 { implicit val json: JSON[C13] = deriveJSON[C13] }
+  case class C14(x: Int) extends Wide
+  object C14 { implicit val json: JSON[C14] = deriveJSON[C14] }
+  case class C15(x: Int) extends Wide
+  object C15 { implicit val json: JSON[C15] = deriveJSON[C15] }
+  case class C16(x: Int) extends Wide
+  object C16 { implicit val json: JSON[C16] = deriveJSON[C16] }
+  case class C17(x: Int) extends Wide
+  object C17 { implicit val json: JSON[C17] = deriveJSON[C17] }
+  case class C18(x: Int) extends Wide
+  object C18 { implicit val json: JSON[C18] = deriveJSON[C18] }
+  case class C19(x: Int) extends Wide
+  object C19 { implicit val json: JSON[C19] = deriveJSON[C19] }
+  case class C20(x: Int) extends Wide
+  object C20 { implicit val json: JSON[C20] = deriveJSON[C20] }
+  case class C21(x: Int) extends Wide
+  object C21 { implicit val json: JSON[C21] = deriveJSON[C21] }
+  case class C22(x: Int) extends Wide
+  object C22 { implicit val json: JSON[C22] = deriveJSON[C22] }
+  case class C23(x: Int) extends Wide
+  object C23 { implicit val json: JSON[C23] = deriveJSON[C23] }
+  case class C24(x: Int) extends Wide
+  object C24 { implicit val json: JSON[C24] = deriveJSON[C24] }
+  case class C25(x: Int) extends Wide
+  object C25 { implicit val json: JSON[C25] = deriveJSON[C25] }
+  case class C26(x: Int) extends Wide
+  object C26 { implicit val json: JSON[C26] = deriveJSON[C26] }
+  case class C27(x: Int) extends Wide
+  object C27 { implicit val json: JSON[C27] = deriveJSON[C27] }
+  case class C28(x: Int) extends Wide
+  object C28 { implicit val json: JSON[C28] = deriveJSON[C28] }
+  case class C29(x: Int) extends Wide
+  object C29 { implicit val json: JSON[C29] = deriveJSON[C29] }
+  case class C30(x: Int) extends Wide
+  object C30 { implicit val json: JSON[C30] = deriveJSON[C30] }
+  case class C31(x: Int) extends Wide
+  object C31 { implicit val json: JSON[C31] = deriveJSON[C31] }
+  case class C32(x: Int) extends Wide
+  object C32 { implicit val json: JSON[C32] = deriveJSON[C32] }
+  case class C33(x: Int) extends Wide
+  object C33 { implicit val json: JSON[C33] = deriveJSON[C33] }
+  case class C34(x: Int) extends Wide
+  object C34 { implicit val json: JSON[C34] = deriveJSON[C34] }
+  case class C35(x: Int) extends Wide
+  object C35 { implicit val json: JSON[C35] = deriveJSON[C35] }
+  case class C36(x: Int) extends Wide
+  object C36 { implicit val json: JSON[C36] = deriveJSON[C36] }
+  case class C37(x: Int) extends Wide
+  object C37 { implicit val json: JSON[C37] = deriveJSON[C37] }
+  case class C38(x: Int) extends Wide
+  object C38 { implicit val json: JSON[C38] = deriveJSON[C38] }
+  case class C39(x: Int) extends Wide
+  object C39 { implicit val json: JSON[C39] = deriveJSON[C39] }
+  case class C40(x: Int) extends Wide
+  object C40 { implicit val json: JSON[C40] = deriveJSON[C40] }
+  case class C41(x: Int) extends Wide
+  object C41 { implicit val json: JSON[C41] = deriveJSON[C41] }
+  case class C42(x: Int) extends Wide
+  object C42 { implicit val json: JSON[C42] = deriveJSON[C42] }
+  case class C43(x: Int) extends Wide
+  object C43 { implicit val json: JSON[C43] = deriveJSON[C43] }
+  case class C44(x: Int) extends Wide
+  object C44 { implicit val json: JSON[C44] = deriveJSON[C44] }
+  case class C45(x: Int) extends Wide
+  object C45 { implicit val json: JSON[C45] = deriveJSON[C45] }
+  case class C46(x: Int) extends Wide
+  object C46 { implicit val json: JSON[C46] = deriveJSON[C46] }
+  case class C47(x: Int) extends Wide
+  object C47 { implicit val json: JSON[C47] = deriveJSON[C47] }
+  case class C48(x: Int) extends Wide
+  object C48 { implicit val json: JSON[C48] = deriveJSON[C48] }
+  case class C49(x: Int) extends Wide
+  object C49 { implicit val json: JSON[C49] = deriveJSON[C49] }
+  case class C50(x: Int) extends Wide
+  object C50 { implicit val json: JSON[C50] = deriveJSON[C50] }
+  case class C51(x: Int) extends Wide
+  object C51 { implicit val json: JSON[C51] = deriveJSON[C51] }
+  case class C52(x: Int) extends Wide
+  object C52 { implicit val json: JSON[C52] = deriveJSON[C52] }
+  case class C53(x: Int) extends Wide
+  object C53 { implicit val json: JSON[C53] = deriveJSON[C53] }
+  case class C54(x: Int) extends Wide
+  object C54 { implicit val json: JSON[C54] = deriveJSON[C54] }
+  case class C55(x: Int) extends Wide
+  object C55 { implicit val json: JSON[C55] = deriveJSON[C55] }
+  case class C56(x: Int) extends Wide
+  object C56 { implicit val json: JSON[C56] = deriveJSON[C56] }
+  case class C57(x: Int) extends Wide
+  object C57 { implicit val json: JSON[C57] = deriveJSON[C57] }
+  case class C58(x: Int) extends Wide
+  object C58 { implicit val json: JSON[C58] = deriveJSON[C58] }
+  case class C59(x: Int) extends Wide
+  object C59 { implicit val json: JSON[C59] = deriveJSON[C59] }
+  case class C60(x: Int) extends Wide
+  object C60 { implicit val json: JSON[C60] = deriveJSON[C60] }
+  case class C61(x: Int) extends Wide
+  object C61 { implicit val json: JSON[C61] = deriveJSON[C61] }
+  case class C62(x: Int) extends Wide
+  object C62 { implicit val json: JSON[C62] = deriveJSON[C62] }
+  case class C63(x: Int) extends Wide
+  object C63 { implicit val json: JSON[C63] = deriveJSON[C63] }
+  case class C64(x: Int) extends Wide
+  object C64 { implicit val json: JSON[C64] = deriveJSON[C64] }
+  case class C65(x: Int) extends Wide
+  object C65 { implicit val json: JSON[C65] = deriveJSON[C65] }
+  case class C66(x: Int) extends Wide
+  object C66 { implicit val json: JSON[C66] = deriveJSON[C66] }
+  case class C67(x: Int) extends Wide
+  object C67 { implicit val json: JSON[C67] = deriveJSON[C67] }
+  case class C68(x: Int) extends Wide
+  object C68 { implicit val json: JSON[C68] = deriveJSON[C68] }
+  case class C69(x: Int) extends Wide
+  object C69 { implicit val json: JSON[C69] = deriveJSON[C69] }
+  case class C70(x: Int) extends Wide
+  object C70 { implicit val json: JSON[C70] = deriveJSON[C70] }
+  case class C71(x: Int) extends Wide
+  object C71 { implicit val json: JSON[C71] = deriveJSON[C71] }
+  case class C72(x: Int) extends Wide
+  object C72 { implicit val json: JSON[C72] = deriveJSON[C72] }
+  case class C73(x: Int) extends Wide
+  object C73 { implicit val json: JSON[C73] = deriveJSON[C73] }
+  case class C74(x: Int) extends Wide
+  object C74 { implicit val json: JSON[C74] = deriveJSON[C74] }
+  case class C75(x: Int) extends Wide
+  object C75 { implicit val json: JSON[C75] = deriveJSON[C75] }
+  case class C76(x: Int) extends Wide
+  object C76 { implicit val json: JSON[C76] = deriveJSON[C76] }
+  case class C77(x: Int) extends Wide
+  object C77 { implicit val json: JSON[C77] = deriveJSON[C77] }
+  case class C78(x: Int) extends Wide
+  object C78 { implicit val json: JSON[C78] = deriveJSON[C78] }
+  case class C79(x: Int) extends Wide
+  object C79 { implicit val json: JSON[C79] = deriveJSON[C79] }
+  case class C80(x: Int) extends Wide
+  object C80 { implicit val json: JSON[C80] = deriveJSON[C80] }
+  case class C81(x: Int) extends Wide
+  object C81 { implicit val json: JSON[C81] = deriveJSON[C81] }
+  case class C82(x: Int) extends Wide
+  object C82 { implicit val json: JSON[C82] = deriveJSON[C82] }
+  case class C83(x: Int) extends Wide
+  object C83 { implicit val json: JSON[C83] = deriveJSON[C83] }
+  case class C84(x: Int) extends Wide
+  object C84 { implicit val json: JSON[C84] = deriveJSON[C84] }
+  case class C85(x: Int) extends Wide
+  object C85 { implicit val json: JSON[C85] = deriveJSON[C85] }
+  case class C86(x: Int) extends Wide
+  object C86 { implicit val json: JSON[C86] = deriveJSON[C86] }
+  case class C87(x: Int) extends Wide
+  object C87 { implicit val json: JSON[C87] = deriveJSON[C87] }
+  case class C88(x: Int) extends Wide
+  object C88 { implicit val json: JSON[C88] = deriveJSON[C88] }
+  case class C89(x: Int) extends Wide
+  object C89 { implicit val json: JSON[C89] = deriveJSON[C89] }
+  case class C90(x: Int) extends Wide
+  object C90 { implicit val json: JSON[C90] = deriveJSON[C90] }
+  case class C91(x: Int) extends Wide
+  object C91 { implicit val json: JSON[C91] = deriveJSON[C91] }
+  case class C92(x: Int) extends Wide
+  object C92 { implicit val json: JSON[C92] = deriveJSON[C92] }
+  case class C93(x: Int) extends Wide
+  object C93 { implicit val json: JSON[C93] = deriveJSON[C93] }
+  case class C94(x: Int) extends Wide
+  object C94 { implicit val json: JSON[C94] = deriveJSON[C94] }
+  case class C95(x: Int) extends Wide
+  object C95 { implicit val json: JSON[C95] = deriveJSON[C95] }
+  case class C96(x: Int) extends Wide
+  object C96 { implicit val json: JSON[C96] = deriveJSON[C96] }
+  case class C97(x: Int) extends Wide
+  object C97 { implicit val json: JSON[C97] = deriveJSON[C97] }
+  case class C98(x: Int) extends Wide
+  object C98 { implicit val json: JSON[C98] = deriveJSON[C98] }
+  case class C99(x: Int) extends Wide
+  object C99 { implicit val json: JSON[C99] = deriveJSON[C99] }
+  case class C100(x: Int) extends Wide
+  object C100 { implicit val json: JSON[C100] = deriveJSON[C100] }
+  case class C101(x: Int) extends Wide
+  object C101 { implicit val json: JSON[C101] = deriveJSON[C101] }
+  case class C102(x: Int) extends Wide
+  object C102 { implicit val json: JSON[C102] = deriveJSON[C102] }
+  case class C103(x: Int) extends Wide
+  object C103 { implicit val json: JSON[C103] = deriveJSON[C103] }
+  case class C104(x: Int) extends Wide
+  object C104 { implicit val json: JSON[C104] = deriveJSON[C104] }
+  case class C105(x: Int) extends Wide
+  object C105 { implicit val json: JSON[C105] = deriveJSON[C105] }
+  case class C106(x: Int) extends Wide
+  object C106 { implicit val json: JSON[C106] = deriveJSON[C106] }
+  case class C107(x: Int) extends Wide
+  object C107 { implicit val json: JSON[C107] = deriveJSON[C107] }
+  case class C108(x: Int) extends Wide
+  object C108 { implicit val json: JSON[C108] = deriveJSON[C108] }
+  case class C109(x: Int) extends Wide
+  object C109 { implicit val json: JSON[C109] = deriveJSON[C109] }
+  case class C110(x: Int) extends Wide
+  object C110 { implicit val json: JSON[C110] = deriveJSON[C110] }
+  case class C111(x: Int) extends Wide
+  object C111 { implicit val json: JSON[C111] = deriveJSON[C111] }
+  case class C112(x: Int) extends Wide
+  object C112 { implicit val json: JSON[C112] = deriveJSON[C112] }
+  case class C113(x: Int) extends Wide
+  object C113 { implicit val json: JSON[C113] = deriveJSON[C113] }
+  case class C114(x: Int) extends Wide
+  object C114 { implicit val json: JSON[C114] = deriveJSON[C114] }
+  case class C115(x: Int) extends Wide
+  object C115 { implicit val json: JSON[C115] = deriveJSON[C115] }
+  case class C116(x: Int) extends Wide
+  object C116 { implicit val json: JSON[C116] = deriveJSON[C116] }
+  case class C117(x: Int) extends Wide
+  object C117 { implicit val json: JSON[C117] = deriveJSON[C117] }
+  case class C118(x: Int) extends Wide
+  object C118 { implicit val json: JSON[C118] = deriveJSON[C118] }
+  case class C119(x: Int) extends Wide
+  object C119 { implicit val json: JSON[C119] = deriveJSON[C119] }
+  case class C120(x: Int) extends Wide
+  object C120 { implicit val json: JSON[C120] = deriveJSON[C120] }
+  case class C121(x: Int) extends Wide
+  object C121 { implicit val json: JSON[C121] = deriveJSON[C121] }
+  case class C122(x: Int) extends Wide
+  object C122 { implicit val json: JSON[C122] = deriveJSON[C122] }
+  case class C123(x: Int) extends Wide
+  object C123 { implicit val json: JSON[C123] = deriveJSON[C123] }
+  case class C124(x: Int) extends Wide
+  object C124 { implicit val json: JSON[C124] = deriveJSON[C124] }
+  case class C125(x: Int) extends Wide
+  object C125 { implicit val json: JSON[C125] = deriveJSON[C125] }
+  case class C126(x: Int) extends Wide
+  object C126 { implicit val json: JSON[C126] = deriveJSON[C126] }
+  case class C127(x: Int) extends Wide
+  object C127 { implicit val json: JSON[C127] = deriveJSON[C127] }
+  case class C128(x: Int) extends Wide
+  object C128 { implicit val json: JSON[C128] = deriveJSON[C128] }
+  case class C129(x: Int) extends Wide
+  object C129 { implicit val json: JSON[C129] = deriveJSON[C129] }
+  case class C130(x: Int) extends Wide
+  object C130 { implicit val json: JSON[C130] = deriveJSON[C130] }
+  case class C131(x: Int) extends Wide
+  object C131 { implicit val json: JSON[C131] = deriveJSON[C131] }
+  case class C132(x: Int) extends Wide
+  object C132 { implicit val json: JSON[C132] = deriveJSON[C132] }
+  case class C133(x: Int) extends Wide
+  object C133 { implicit val json: JSON[C133] = deriveJSON[C133] }
+  case class C134(x: Int) extends Wide
+  object C134 { implicit val json: JSON[C134] = deriveJSON[C134] }
+  case class C135(x: Int) extends Wide
+  object C135 { implicit val json: JSON[C135] = deriveJSON[C135] }
+  case class C136(x: Int) extends Wide
+  object C136 { implicit val json: JSON[C136] = deriveJSON[C136] }
+  case class C137(x: Int) extends Wide
+  object C137 { implicit val json: JSON[C137] = deriveJSON[C137] }
+  case class C138(x: Int) extends Wide
+  object C138 { implicit val json: JSON[C138] = deriveJSON[C138] }
+  case class C139(x: Int) extends Wide
+  object C139 { implicit val json: JSON[C139] = deriveJSON[C139] }
+  case class C140(x: Int) extends Wide
+  object C140 { implicit val json: JSON[C140] = deriveJSON[C140] }
+  case class C141(x: Int) extends Wide
+  object C141 { implicit val json: JSON[C141] = deriveJSON[C141] }
+  case class C142(x: Int) extends Wide
+  object C142 { implicit val json: JSON[C142] = deriveJSON[C142] }
+  case class C143(x: Int) extends Wide
+  object C143 { implicit val json: JSON[C143] = deriveJSON[C143] }
+  case class C144(x: Int) extends Wide
+  object C144 { implicit val json: JSON[C144] = deriveJSON[C144] }
+  case class C145(x: Int) extends Wide
+  object C145 { implicit val json: JSON[C145] = deriveJSON[C145] }
+  case class C146(x: Int) extends Wide
+  object C146 { implicit val json: JSON[C146] = deriveJSON[C146] }
+  case class C147(x: Int) extends Wide
+  object C147 { implicit val json: JSON[C147] = deriveJSON[C147] }
+  case class C148(x: Int) extends Wide
+  object C148 { implicit val json: JSON[C148] = deriveJSON[C148] }
+  case class C149(x: Int) extends Wide
+  object C149 { implicit val json: JSON[C149] = deriveJSON[C149] }
+  case class C150(x: Int) extends Wide
+  object C150 { implicit val json: JSON[C150] = deriveJSON[C150] }
+  case class C151(x: Int) extends Wide
+  object C151 { implicit val json: JSON[C151] = deriveJSON[C151] }
+  case class C152(x: Int) extends Wide
+  object C152 { implicit val json: JSON[C152] = deriveJSON[C152] }
+  case class C153(x: Int) extends Wide
+  object C153 { implicit val json: JSON[C153] = deriveJSON[C153] }
+  case class C154(x: Int) extends Wide
+  object C154 { implicit val json: JSON[C154] = deriveJSON[C154] }
+  case class C155(x: Int) extends Wide
+  object C155 { implicit val json: JSON[C155] = deriveJSON[C155] }
+  case class C156(x: Int) extends Wide
+  object C156 { implicit val json: JSON[C156] = deriveJSON[C156] }
+  case class C157(x: Int) extends Wide
+  object C157 { implicit val json: JSON[C157] = deriveJSON[C157] }
+  case class C158(x: Int) extends Wide
+  object C158 { implicit val json: JSON[C158] = deriveJSON[C158] }
+  case class C159(x: Int) extends Wide
+  object C159 { implicit val json: JSON[C159] = deriveJSON[C159] }
+  case class C160(x: Int) extends Wide
+  object C160 { implicit val json: JSON[C160] = deriveJSON[C160] }
+  case class C161(x: Int) extends Wide
+  object C161 { implicit val json: JSON[C161] = deriveJSON[C161] }
+  case class C162(x: Int) extends Wide
+  object C162 { implicit val json: JSON[C162] = deriveJSON[C162] }
+  case class C163(x: Int) extends Wide
+  object C163 { implicit val json: JSON[C163] = deriveJSON[C163] }
+  case class C164(x: Int) extends Wide
+  object C164 { implicit val json: JSON[C164] = deriveJSON[C164] }
+  case class C165(x: Int) extends Wide
+  object C165 { implicit val json: JSON[C165] = deriveJSON[C165] }
+  case class C166(x: Int) extends Wide
+  object C166 { implicit val json: JSON[C166] = deriveJSON[C166] }
+  case class C167(x: Int) extends Wide
+  object C167 { implicit val json: JSON[C167] = deriveJSON[C167] }
+  case class C168(x: Int) extends Wide
+  object C168 { implicit val json: JSON[C168] = deriveJSON[C168] }
+  case class C169(x: Int) extends Wide
+  object C169 { implicit val json: JSON[C169] = deriveJSON[C169] }
+  case class C170(x: Int) extends Wide
+  object C170 { implicit val json: JSON[C170] = deriveJSON[C170] }
+  case class C171(x: Int) extends Wide
+  object C171 { implicit val json: JSON[C171] = deriveJSON[C171] }
+  case class C172(x: Int) extends Wide
+  object C172 { implicit val json: JSON[C172] = deriveJSON[C172] }
+  case class C173(x: Int) extends Wide
+  object C173 { implicit val json: JSON[C173] = deriveJSON[C173] }
+  case class C174(x: Int) extends Wide
+  object C174 { implicit val json: JSON[C174] = deriveJSON[C174] }
+  case class C175(x: Int) extends Wide
+  object C175 { implicit val json: JSON[C175] = deriveJSON[C175] }
+  case class C176(x: Int) extends Wide
+  object C176 { implicit val json: JSON[C176] = deriveJSON[C176] }
+  case class C177(x: Int) extends Wide
+  object C177 { implicit val json: JSON[C177] = deriveJSON[C177] }
+  case class C178(x: Int) extends Wide
+  object C178 { implicit val json: JSON[C178] = deriveJSON[C178] }
+  case class C179(x: Int) extends Wide
+  object C179 { implicit val json: JSON[C179] = deriveJSON[C179] }
+  case class C180(x: Int) extends Wide
+  object C180 { implicit val json: JSON[C180] = deriveJSON[C180] }
+  case class C181(x: Int) extends Wide
+  object C181 { implicit val json: JSON[C181] = deriveJSON[C181] }
+  case class C182(x: Int) extends Wide
+  object C182 { implicit val json: JSON[C182] = deriveJSON[C182] }
+  case class C183(x: Int) extends Wide
+  object C183 { implicit val json: JSON[C183] = deriveJSON[C183] }
+  case class C184(x: Int) extends Wide
+  object C184 { implicit val json: JSON[C184] = deriveJSON[C184] }
+  case class C185(x: Int) extends Wide
+  object C185 { implicit val json: JSON[C185] = deriveJSON[C185] }
+  case class C186(x: Int) extends Wide
+  object C186 { implicit val json: JSON[C186] = deriveJSON[C186] }
+  case class C187(x: Int) extends Wide
+  object C187 { implicit val json: JSON[C187] = deriveJSON[C187] }
+  case class C188(x: Int) extends Wide
+  object C188 { implicit val json: JSON[C188] = deriveJSON[C188] }
+  case class C189(x: Int) extends Wide
+  object C189 { implicit val json: JSON[C189] = deriveJSON[C189] }
+  case class C190(x: Int) extends Wide
+  object C190 { implicit val json: JSON[C190] = deriveJSON[C190] }
+  case class C191(x: Int) extends Wide
+  object C191 { implicit val json: JSON[C191] = deriveJSON[C191] }
+  case class C192(x: Int) extends Wide
+  object C192 { implicit val json: JSON[C192] = deriveJSON[C192] }
+  case class C193(x: Int) extends Wide
+  object C193 { implicit val json: JSON[C193] = deriveJSON[C193] }
+  case class C194(x: Int) extends Wide
+  object C194 { implicit val json: JSON[C194] = deriveJSON[C194] }
+  case class C195(x: Int) extends Wide
+  object C195 { implicit val json: JSON[C195] = deriveJSON[C195] }
+  case class C196(x: Int) extends Wide
+  object C196 { implicit val json: JSON[C196] = deriveJSON[C196] }
+  case class C197(x: Int) extends Wide
+  object C197 { implicit val json: JSON[C197] = deriveJSON[C197] }
+  case class C198(x: Int) extends Wide
+  object C198 { implicit val json: JSON[C198] = deriveJSON[C198] }
+  case class C199(x: Int) extends Wide
+  object C199 { implicit val json: JSON[C199] = deriveJSON[C199] }
+  case class C200(x: Int) extends Wide
+  object C200 { implicit val json: JSON[C200] = deriveJSON[C200] }
+  // format: on
+
+  val json: JSON[Wide] = jsonTypeSwitch[Wide](
+    List(
+      sub[C1],
+      sub[C2],
+      sub[C3],
+      sub[C4],
+      sub[C5],
+      sub[C6],
+      sub[C7],
+      sub[C8],
+      sub[C9],
+      sub[C10],
+      sub[C11],
+      sub[C12],
+      sub[C13],
+      sub[C14],
+      sub[C15],
+      sub[C16],
+      sub[C17],
+      sub[C18],
+      sub[C19],
+      sub[C20],
+      sub[C21],
+      sub[C22],
+      sub[C23],
+      sub[C24],
+      sub[C25],
+      sub[C26],
+      sub[C27],
+      sub[C28],
+      sub[C29],
+      sub[C30],
+      sub[C31],
+      sub[C32],
+      sub[C33],
+      sub[C34],
+      sub[C35],
+      sub[C36],
+      sub[C37],
+      sub[C38],
+      sub[C39],
+      sub[C40],
+      sub[C41],
+      sub[C42],
+      sub[C43],
+      sub[C44],
+      sub[C45],
+      sub[C46],
+      sub[C47],
+      sub[C48],
+      sub[C49],
+      sub[C50],
+      sub[C51],
+      sub[C52],
+      sub[C53],
+      sub[C54],
+      sub[C55],
+      sub[C56],
+      sub[C57],
+      sub[C58],
+      sub[C59],
+      sub[C60],
+      sub[C61],
+      sub[C62],
+      sub[C63],
+      sub[C64],
+      sub[C65],
+      sub[C66],
+      sub[C67],
+      sub[C68],
+      sub[C69],
+      sub[C70],
+      sub[C71],
+      sub[C72],
+      sub[C73],
+      sub[C74],
+      sub[C75],
+      sub[C76],
+      sub[C77],
+      sub[C78],
+      sub[C79],
+      sub[C80],
+      sub[C81],
+      sub[C82],
+      sub[C83],
+      sub[C84],
+      sub[C85],
+      sub[C86],
+      sub[C87],
+      sub[C88],
+      sub[C89],
+      sub[C90],
+      sub[C91],
+      sub[C92],
+      sub[C93],
+      sub[C94],
+      sub[C95],
+      sub[C96],
+      sub[C97],
+      sub[C98],
+      sub[C99],
+      sub[C100],
+      sub[C101],
+      sub[C102],
+      sub[C103],
+      sub[C104],
+      sub[C105],
+      sub[C106],
+      sub[C107],
+      sub[C108],
+      sub[C109],
+      sub[C110],
+      sub[C111],
+      sub[C112],
+      sub[C113],
+      sub[C114],
+      sub[C115],
+      sub[C116],
+      sub[C117],
+      sub[C118],
+      sub[C119],
+      sub[C120],
+      sub[C121],
+      sub[C122],
+      sub[C123],
+      sub[C124],
+      sub[C125],
+      sub[C126],
+      sub[C127],
+      sub[C128],
+      sub[C129],
+      sub[C130],
+      sub[C131],
+      sub[C132],
+      sub[C133],
+      sub[C134],
+      sub[C135],
+      sub[C136],
+      sub[C137],
+      sub[C138],
+      sub[C139],
+      sub[C140],
+      sub[C141],
+      sub[C142],
+      sub[C143],
+      sub[C144],
+      sub[C145],
+      sub[C146],
+      sub[C147],
+      sub[C148],
+      sub[C149],
+      sub[C150],
+      sub[C151],
+      sub[C152],
+      sub[C153],
+      sub[C154],
+      sub[C155],
+      sub[C156],
+      sub[C157],
+      sub[C158],
+      sub[C159],
+      sub[C160],
+      sub[C161],
+      sub[C162],
+      sub[C163],
+      sub[C164],
+      sub[C165],
+      sub[C166],
+      sub[C167],
+      sub[C168],
+      sub[C169],
+      sub[C170],
+      sub[C171],
+      sub[C172],
+      sub[C173],
+      sub[C174],
+      sub[C175],
+      sub[C176],
+      sub[C177],
+      sub[C178],
+      sub[C179],
+      sub[C180],
+      sub[C181],
+      sub[C182],
+      sub[C183],
+      sub[C184],
+      sub[C185],
+      sub[C186],
+      sub[C187],
+      sub[C188],
+      sub[C189],
+      sub[C190],
+      sub[C191],
+      sub[C192],
+      sub[C193],
+      sub[C194],
+      sub[C195],
+      sub[C196],
+      sub[C197],
+      sub[C198],
+      sub[C199],
+      sub[C200]
+    ))
+
+  val values: List[Wide] = List(
+    C1(1),
+    C2(2),
+    C3(3),
+    C4(4),
+    C5(5),
+    C6(6),
+    C7(7),
+    C8(8),
+    C9(9),
+    C10(10),
+    C11(11),
+    C12(12),
+    C13(13),
+    C14(14),
+    C15(15),
+    C16(16),
+    C17(17),
+    C18(18),
+    C19(19),
+    C20(20),
+    C21(21),
+    C22(22),
+    C23(23),
+    C24(24),
+    C25(25),
+    C26(26),
+    C27(27),
+    C28(28),
+    C29(29),
+    C30(30),
+    C31(31),
+    C32(32),
+    C33(33),
+    C34(34),
+    C35(35),
+    C36(36),
+    C37(37),
+    C38(38),
+    C39(39),
+    C40(40),
+    C41(41),
+    C42(42),
+    C43(43),
+    C44(44),
+    C45(45),
+    C46(46),
+    C47(47),
+    C48(48),
+    C49(49),
+    C50(50),
+    C51(51),
+    C52(52),
+    C53(53),
+    C54(54),
+    C55(55),
+    C56(56),
+    C57(57),
+    C58(58),
+    C59(59),
+    C60(60),
+    C61(61),
+    C62(62),
+    C63(63),
+    C64(64),
+    C65(65),
+    C66(66),
+    C67(67),
+    C68(68),
+    C69(69),
+    C70(70),
+    C71(71),
+    C72(72),
+    C73(73),
+    C74(74),
+    C75(75),
+    C76(76),
+    C77(77),
+    C78(78),
+    C79(79),
+    C80(80),
+    C81(81),
+    C82(82),
+    C83(83),
+    C84(84),
+    C85(85),
+    C86(86),
+    C87(87),
+    C88(88),
+    C89(89),
+    C90(90),
+    C91(91),
+    C92(92),
+    C93(93),
+    C94(94),
+    C95(95),
+    C96(96),
+    C97(97),
+    C98(98),
+    C99(99),
+    C100(100),
+    C101(101),
+    C102(102),
+    C103(103),
+    C104(104),
+    C105(105),
+    C106(106),
+    C107(107),
+    C108(108),
+    C109(109),
+    C110(110),
+    C111(111),
+    C112(112),
+    C113(113),
+    C114(114),
+    C115(115),
+    C116(116),
+    C117(117),
+    C118(118),
+    C119(119),
+    C120(120),
+    C121(121),
+    C122(122),
+    C123(123),
+    C124(124),
+    C125(125),
+    C126(126),
+    C127(127),
+    C128(128),
+    C129(129),
+    C130(130),
+    C131(131),
+    C132(132),
+    C133(133),
+    C134(134),
+    C135(135),
+    C136(136),
+    C137(137),
+    C138(138),
+    C139(139),
+    C140(140),
+    C141(141),
+    C142(142),
+    C143(143),
+    C144(144),
+    C145(145),
+    C146(146),
+    C147(147),
+    C148(148),
+    C149(149),
+    C150(150),
+    C151(151),
+    C152(152),
+    C153(153),
+    C154(154),
+    C155(155),
+    C156(156),
+    C157(157),
+    C158(158),
+    C159(159),
+    C160(160),
+    C161(161),
+    C162(162),
+    C163(163),
+    C164(164),
+    C165(165),
+    C166(166),
+    C167(167),
+    C168(168),
+    C169(169),
+    C170(170),
+    C171(171),
+    C172(172),
+    C173(173),
+    C174(174),
+    C175(175),
+    C176(176),
+    C177(177),
+    C178(178),
+    C179(179),
+    C180(180),
+    C181(181),
+    C182(182),
+    C183(183),
+    C184(184),
+    C185(185),
+    C186(186),
+    C187(187),
+    C188(188),
+    C189(189),
+    C190(190),
+    C191(191),
+    C192(192),
+    C193(193),
+    C194(194),
+    C195(195),
+    C196(196),
+    C197(197),
+    C198(198),
+    C199(199),
+    C200(200)
+  )
+}

--- a/mongo/mongo-derivation/src/main/scala/io/sphere/mongo/generic/MongoFormatMacros.scala
+++ b/mongo/mongo-derivation/src/main/scala/io/sphere/mongo/generic/MongoFormatMacros.scala
@@ -153,19 +153,13 @@ private[generic] object MongoFormatMacros {
             }
           }.toList
 
+          val pkg = reify(io.sphere.mongo.generic.`package`).tree
+          val subs = idents.tail.map(i => q"$pkg.sub[$i]")
+
           c.Expr[MongoFormat[A]](
             Block(
               instanceDefs,
-              Apply(
-                TypeApply(
-                  Select(
-                    reify(io.sphere.mongo.generic.`package`).tree,
-                    TermName("mongoTypeSwitch")
-                  ),
-                  idents
-                ),
-                q"$typeSelectors" :: Nil
-              )
+              q"$pkg.mongoTypeSwitch[${idents.head}](_root_.scala.List(..$subs) ::: $typeSelectors)"
             )
           )
         }

--- a/mongo/mongo-derivation/src/main/scala/io/sphere/mongo/generic/package.fmpp.scala
+++ b/mongo/mongo-derivation/src/main/scala/io/sphere/mongo/generic/package.fmpp.scala
@@ -113,15 +113,13 @@ package object generic extends Logging {
   </#list>
 
 
-  /** Derives a `MongoFormat[T]` instance for some supertype `T`. The instance acts as a type-switch
-    * for the subtypes `A1` and `A2`, delegating to their respective MongoFormat instances based
-    * on a field that acts as a type hint. */
-  def mongoTypeSwitch[T: ClassTag, A1 <: T: ClassTag: MongoFormat, A2 <: T: ClassTag: MongoFormat](
-      selectors: List[TypeSelector[_]]): MongoFormat[T] with MongoTypeSelectorContainer = {
-    val allSelectors = typeSelector[A1]() :: typeSelector[A2]() :: selectors
+  /** Creates a `MongoFormat[T]` that switches on a type-hint field, delegating to the given subtype
+    * selectors' instances. */
+  def mongoTypeSwitch[T: ClassTag](selectors: List[TypeSelector[_]]): MongoFormat[T] with MongoTypeSelectorContainer = {
+    require(selectors.nonEmpty, "mongoTypeSwitch needs at least one subtype")
     val readMapBuilder = Map.newBuilder[String, TypeSelector[_]]
     val writeMapBuilder = Map.newBuilder[Class[_], TypeSelector[_]]
-    allSelectors.foreach { s =>
+    selectors.foreach { s =>
       readMapBuilder += (s.typeValue -> s)
       writeMapBuilder += (s.clazz -> s)
     }
@@ -157,21 +155,9 @@ package object generic extends Logging {
           }
           case None => new BasicDBObject(defaultTypeFieldName, defaultTypeValue(t.getClass))
         }
-      override def typeSelectors: List[TypeSelector[_]] = allSelectors
+      override def typeSelectors: List[TypeSelector[_]] = selectors
     }
   }
-
-  // special case with only one sub-type
-  def mongoTypeSwitch[T: ClassTag, A1 <: T: ClassTag: MongoFormat](selectors: List[TypeSelector[_]]): MongoFormat[T] =
-    mongoTypeSwitch[T, A1, A1](selectors)
-
-  <#list 3..126 as i>
-  <#assign typeParams><#list 1..i-1 as j>A${j}<#if i-1 != j>,</#if></#list></#assign>
-  <#assign implTypeParams><#list 1..i as j>A${j} <: T : MongoFormat : ClassTag<#if i !=j>,</#if></#list></#assign>
-  def mongoTypeSwitch[T: ClassTag, ${implTypeParams}](selectors: List[TypeSelector[_]]): MongoFormat[T] with MongoTypeSelectorContainer =
-    mongoTypeSwitch[T, ${typeParams}](typeSelector[A${i}]() :: selectors)
-  </#list>
-
 
   trait MongoTypeSelectorContainer {
     def typeSelectors: List[TypeSelector[_]]
@@ -271,11 +257,12 @@ package object generic extends Logging {
   private def findTypeValue(dbo: BSONObject, typeField: String): Option[String] =
     Option(dbo.get(typeField)).map(_.toString)
 
-  private def typeSelector[A: ClassTag: MongoFormat](): TypeSelector[_] = {
+  /** Builds the selector for the subtype `A` of a `mongoTypeSwitch`. */
+  def sub[A: ClassTag: MongoFormat]: TypeSelector[A] = {
     val clazz = classTag[A].runtimeClass
-    val (_, typeValue) = getMongoClassMeta(clazz).typeHint match {
-      case Some(hint) => (hint.field, hint.value)
-      case None => (defaultTypeFieldName, defaultTypeValue(clazz))
+    val typeValue = getMongoClassMeta(clazz).typeHint match {
+      case Some(hint) => hint.value
+      case None => defaultTypeValue(clazz)
     }
     new TypeSelector[A](typeValue, clazz)
   }

--- a/mongo/mongo-derivation/src/test/scala/io/sphere/mongo/generic/MongoTypeSelectorContainerSpec.scala
+++ b/mongo/mongo-derivation/src/test/scala/io/sphere/mongo/generic/MongoTypeSelectorContainerSpec.scala
@@ -15,7 +15,7 @@ class MongoTypeSelectorContainerSpec extends AnyWordSpec with Matchers {
     val typeSelectors2 = CartEvent2.mongo.asInstanceOf[MongoTypeSelectorContainer].typeSelectors
 
     val mergedInstance: MongoFormat[CartEvent] =
-      mongoTypeSwitch[CartEvent, CartEvent1](typeSelectors1 ::: typeSelectors2)
+      mongoTypeSwitch[CartEvent](typeSelectors1 ::: typeSelectors2)
 
     val ce1a = SpecificEvent1A("asd2")
     val ce2b = SpecificEvent2B("asd3")

--- a/mongo/mongo-derivation/src/test/scala/io/sphere/mongo/generic/MongoTypeSwitchSpec.scala
+++ b/mongo/mongo-derivation/src/test/scala/io/sphere/mongo/generic/MongoTypeSwitchSpec.scala
@@ -12,7 +12,7 @@ class MongoTypeSwitchSpec extends AnyWordSpec with Matchers {
 
   "mongoTypeSwitch" must {
     "derive a subset of a sealed trait" in {
-      val format = mongoTypeSwitch[A, B, C](Nil)
+      val format = mongoTypeSwitch[A](List(sub[B], sub[C]))
 
       val b = B(123)
       val bson = format.toMongoValue(b)
@@ -30,7 +30,7 @@ class MongoTypeSwitchSpec extends AnyWordSpec with Matchers {
     }
 
     "derive a subset of a sealed trait with a mongoKey" in {
-      val format = mongoTypeSwitch[A, B, D](Nil)
+      val format = mongoTypeSwitch[A](List(sub[B], sub[D]))
 
       val d = D(123)
       val bson = format.toMongoValue(d).asInstanceOf[BSONObject]
@@ -41,15 +41,23 @@ class MongoTypeSwitchSpec extends AnyWordSpec with Matchers {
 
     }
 
+    "honour a @MongoTypeHint on a subtype that is not a direct child" in {
+      val format = mongoTypeSwitch[Top](List(sub[Leaf]))
+
+      val bson = format.toMongoValue(Leaf(1)).asInstanceOf[BSONObject]
+      bson.get("type") must be("LeafHint")
+      format.fromMongoValue(bson) must be(Leaf(1))
+    }
+
     "throw a descriptive error when the type field is missing" in {
-      val format = mongoTypeSwitch[A, B, C](Nil)
+      val format = mongoTypeSwitch[A](List(sub[B], sub[C]))
       val bson = dbObj("int" -> 1)
       val ex = intercept[Exception](format.fromMongoValue(bson))
       ex.getMessage must be("""Missing type field 'type' in DBObject '{"int": 1}'.""")
     }
 
     "throw a descriptive error for an unknown type field value" in {
-      val format = mongoTypeSwitch[A, B, C](Nil)
+      val format = mongoTypeSwitch[A](List(sub[B], sub[C]))
       val bson = dbObj("int" -> 1, "type" -> "Nope")
       val ex = intercept[Exception](format.fromMongoValue(bson))
       ex.getMessage must be(
@@ -71,5 +79,12 @@ object MongoTypeSwitchSpec {
   @MongoTypeHint("D2") case class D(int: Int) extends A
   object D {
     implicit val mongo: MongoFormat[D] = deriveMongoFormat
+  }
+
+  sealed trait Top
+  sealed trait Mid extends Top
+  @MongoTypeHint("LeafHint") case class Leaf(int: Int) extends Mid
+  object Leaf {
+    implicit val mongo: MongoFormat[Leaf] = deriveMongoFormat
   }
 }

--- a/mongo/mongo-derivation/src/test/scala/io/sphere/mongo/generic/WideTypeSwitchSpec.scala
+++ b/mongo/mongo-derivation/src/test/scala/io/sphere/mongo/generic/WideTypeSwitchSpec.scala
@@ -1,0 +1,842 @@
+package io.sphere.mongo.generic
+
+import io.sphere.mongo.format.DefaultMongoFormats._
+import io.sphere.mongo.format.MongoFormat
+import org.scalatest.matchers.must.Matchers
+import org.scalatest.wordspec.AnyWordSpec
+
+/** A sealed trait far wider than `mongoTypeSwitch` used to support: Scala 2 was capped at ~125
+  * subtypes by the JVM method-parameter limit, Scala 3 at 8 by the generated overloads. If either
+  * ceiling comes back, this stops compiling.
+  *
+  * Each subtype's instance lives in its own companion, so the derivations land in 200 tiny class
+  * initialisers instead of one huge one.
+  */
+class WideTypeSwitchSpec extends AnyWordSpec with Matchers {
+  import WideTypeSwitchSpec._
+
+  "mongoTypeSwitch" must {
+    s"round-trip all ${values.size} subtypes" in
+      values.foreach(v => mongo.fromMongoValue(mongo.toMongoValue(v)) must be(v))
+  }
+
+  "deriveMongoFormat" must {
+    s"round-trip all ${values.size} subtypes" in
+      values.foreach(v => derived.fromMongoValue(derived.toMongoValue(v)) must be(v))
+  }
+}
+
+object WideTypeSwitchSpec {
+  sealed trait Wide
+  // format: off
+  case class C1(x: Int) extends Wide
+  object C1 { implicit val mongo: MongoFormat[C1] = deriveMongoFormat }
+  case class C2(x: Int) extends Wide
+  object C2 { implicit val mongo: MongoFormat[C2] = deriveMongoFormat }
+  case class C3(x: Int) extends Wide
+  object C3 { implicit val mongo: MongoFormat[C3] = deriveMongoFormat }
+  case class C4(x: Int) extends Wide
+  object C4 { implicit val mongo: MongoFormat[C4] = deriveMongoFormat }
+  case class C5(x: Int) extends Wide
+  object C5 { implicit val mongo: MongoFormat[C5] = deriveMongoFormat }
+  case class C6(x: Int) extends Wide
+  object C6 { implicit val mongo: MongoFormat[C6] = deriveMongoFormat }
+  case class C7(x: Int) extends Wide
+  object C7 { implicit val mongo: MongoFormat[C7] = deriveMongoFormat }
+  case class C8(x: Int) extends Wide
+  object C8 { implicit val mongo: MongoFormat[C8] = deriveMongoFormat }
+  case class C9(x: Int) extends Wide
+  object C9 { implicit val mongo: MongoFormat[C9] = deriveMongoFormat }
+  case class C10(x: Int) extends Wide
+  object C10 { implicit val mongo: MongoFormat[C10] = deriveMongoFormat }
+  case class C11(x: Int) extends Wide
+  object C11 { implicit val mongo: MongoFormat[C11] = deriveMongoFormat }
+  case class C12(x: Int) extends Wide
+  object C12 { implicit val mongo: MongoFormat[C12] = deriveMongoFormat }
+  case class C13(x: Int) extends Wide
+  object C13 { implicit val mongo: MongoFormat[C13] = deriveMongoFormat }
+  case class C14(x: Int) extends Wide
+  object C14 { implicit val mongo: MongoFormat[C14] = deriveMongoFormat }
+  case class C15(x: Int) extends Wide
+  object C15 { implicit val mongo: MongoFormat[C15] = deriveMongoFormat }
+  case class C16(x: Int) extends Wide
+  object C16 { implicit val mongo: MongoFormat[C16] = deriveMongoFormat }
+  case class C17(x: Int) extends Wide
+  object C17 { implicit val mongo: MongoFormat[C17] = deriveMongoFormat }
+  case class C18(x: Int) extends Wide
+  object C18 { implicit val mongo: MongoFormat[C18] = deriveMongoFormat }
+  case class C19(x: Int) extends Wide
+  object C19 { implicit val mongo: MongoFormat[C19] = deriveMongoFormat }
+  case class C20(x: Int) extends Wide
+  object C20 { implicit val mongo: MongoFormat[C20] = deriveMongoFormat }
+  case class C21(x: Int) extends Wide
+  object C21 { implicit val mongo: MongoFormat[C21] = deriveMongoFormat }
+  case class C22(x: Int) extends Wide
+  object C22 { implicit val mongo: MongoFormat[C22] = deriveMongoFormat }
+  case class C23(x: Int) extends Wide
+  object C23 { implicit val mongo: MongoFormat[C23] = deriveMongoFormat }
+  case class C24(x: Int) extends Wide
+  object C24 { implicit val mongo: MongoFormat[C24] = deriveMongoFormat }
+  case class C25(x: Int) extends Wide
+  object C25 { implicit val mongo: MongoFormat[C25] = deriveMongoFormat }
+  case class C26(x: Int) extends Wide
+  object C26 { implicit val mongo: MongoFormat[C26] = deriveMongoFormat }
+  case class C27(x: Int) extends Wide
+  object C27 { implicit val mongo: MongoFormat[C27] = deriveMongoFormat }
+  case class C28(x: Int) extends Wide
+  object C28 { implicit val mongo: MongoFormat[C28] = deriveMongoFormat }
+  case class C29(x: Int) extends Wide
+  object C29 { implicit val mongo: MongoFormat[C29] = deriveMongoFormat }
+  case class C30(x: Int) extends Wide
+  object C30 { implicit val mongo: MongoFormat[C30] = deriveMongoFormat }
+  case class C31(x: Int) extends Wide
+  object C31 { implicit val mongo: MongoFormat[C31] = deriveMongoFormat }
+  case class C32(x: Int) extends Wide
+  object C32 { implicit val mongo: MongoFormat[C32] = deriveMongoFormat }
+  case class C33(x: Int) extends Wide
+  object C33 { implicit val mongo: MongoFormat[C33] = deriveMongoFormat }
+  case class C34(x: Int) extends Wide
+  object C34 { implicit val mongo: MongoFormat[C34] = deriveMongoFormat }
+  case class C35(x: Int) extends Wide
+  object C35 { implicit val mongo: MongoFormat[C35] = deriveMongoFormat }
+  case class C36(x: Int) extends Wide
+  object C36 { implicit val mongo: MongoFormat[C36] = deriveMongoFormat }
+  case class C37(x: Int) extends Wide
+  object C37 { implicit val mongo: MongoFormat[C37] = deriveMongoFormat }
+  case class C38(x: Int) extends Wide
+  object C38 { implicit val mongo: MongoFormat[C38] = deriveMongoFormat }
+  case class C39(x: Int) extends Wide
+  object C39 { implicit val mongo: MongoFormat[C39] = deriveMongoFormat }
+  case class C40(x: Int) extends Wide
+  object C40 { implicit val mongo: MongoFormat[C40] = deriveMongoFormat }
+  case class C41(x: Int) extends Wide
+  object C41 { implicit val mongo: MongoFormat[C41] = deriveMongoFormat }
+  case class C42(x: Int) extends Wide
+  object C42 { implicit val mongo: MongoFormat[C42] = deriveMongoFormat }
+  case class C43(x: Int) extends Wide
+  object C43 { implicit val mongo: MongoFormat[C43] = deriveMongoFormat }
+  case class C44(x: Int) extends Wide
+  object C44 { implicit val mongo: MongoFormat[C44] = deriveMongoFormat }
+  case class C45(x: Int) extends Wide
+  object C45 { implicit val mongo: MongoFormat[C45] = deriveMongoFormat }
+  case class C46(x: Int) extends Wide
+  object C46 { implicit val mongo: MongoFormat[C46] = deriveMongoFormat }
+  case class C47(x: Int) extends Wide
+  object C47 { implicit val mongo: MongoFormat[C47] = deriveMongoFormat }
+  case class C48(x: Int) extends Wide
+  object C48 { implicit val mongo: MongoFormat[C48] = deriveMongoFormat }
+  case class C49(x: Int) extends Wide
+  object C49 { implicit val mongo: MongoFormat[C49] = deriveMongoFormat }
+  case class C50(x: Int) extends Wide
+  object C50 { implicit val mongo: MongoFormat[C50] = deriveMongoFormat }
+  case class C51(x: Int) extends Wide
+  object C51 { implicit val mongo: MongoFormat[C51] = deriveMongoFormat }
+  case class C52(x: Int) extends Wide
+  object C52 { implicit val mongo: MongoFormat[C52] = deriveMongoFormat }
+  case class C53(x: Int) extends Wide
+  object C53 { implicit val mongo: MongoFormat[C53] = deriveMongoFormat }
+  case class C54(x: Int) extends Wide
+  object C54 { implicit val mongo: MongoFormat[C54] = deriveMongoFormat }
+  case class C55(x: Int) extends Wide
+  object C55 { implicit val mongo: MongoFormat[C55] = deriveMongoFormat }
+  case class C56(x: Int) extends Wide
+  object C56 { implicit val mongo: MongoFormat[C56] = deriveMongoFormat }
+  case class C57(x: Int) extends Wide
+  object C57 { implicit val mongo: MongoFormat[C57] = deriveMongoFormat }
+  case class C58(x: Int) extends Wide
+  object C58 { implicit val mongo: MongoFormat[C58] = deriveMongoFormat }
+  case class C59(x: Int) extends Wide
+  object C59 { implicit val mongo: MongoFormat[C59] = deriveMongoFormat }
+  case class C60(x: Int) extends Wide
+  object C60 { implicit val mongo: MongoFormat[C60] = deriveMongoFormat }
+  case class C61(x: Int) extends Wide
+  object C61 { implicit val mongo: MongoFormat[C61] = deriveMongoFormat }
+  case class C62(x: Int) extends Wide
+  object C62 { implicit val mongo: MongoFormat[C62] = deriveMongoFormat }
+  case class C63(x: Int) extends Wide
+  object C63 { implicit val mongo: MongoFormat[C63] = deriveMongoFormat }
+  case class C64(x: Int) extends Wide
+  object C64 { implicit val mongo: MongoFormat[C64] = deriveMongoFormat }
+  case class C65(x: Int) extends Wide
+  object C65 { implicit val mongo: MongoFormat[C65] = deriveMongoFormat }
+  case class C66(x: Int) extends Wide
+  object C66 { implicit val mongo: MongoFormat[C66] = deriveMongoFormat }
+  case class C67(x: Int) extends Wide
+  object C67 { implicit val mongo: MongoFormat[C67] = deriveMongoFormat }
+  case class C68(x: Int) extends Wide
+  object C68 { implicit val mongo: MongoFormat[C68] = deriveMongoFormat }
+  case class C69(x: Int) extends Wide
+  object C69 { implicit val mongo: MongoFormat[C69] = deriveMongoFormat }
+  case class C70(x: Int) extends Wide
+  object C70 { implicit val mongo: MongoFormat[C70] = deriveMongoFormat }
+  case class C71(x: Int) extends Wide
+  object C71 { implicit val mongo: MongoFormat[C71] = deriveMongoFormat }
+  case class C72(x: Int) extends Wide
+  object C72 { implicit val mongo: MongoFormat[C72] = deriveMongoFormat }
+  case class C73(x: Int) extends Wide
+  object C73 { implicit val mongo: MongoFormat[C73] = deriveMongoFormat }
+  case class C74(x: Int) extends Wide
+  object C74 { implicit val mongo: MongoFormat[C74] = deriveMongoFormat }
+  case class C75(x: Int) extends Wide
+  object C75 { implicit val mongo: MongoFormat[C75] = deriveMongoFormat }
+  case class C76(x: Int) extends Wide
+  object C76 { implicit val mongo: MongoFormat[C76] = deriveMongoFormat }
+  case class C77(x: Int) extends Wide
+  object C77 { implicit val mongo: MongoFormat[C77] = deriveMongoFormat }
+  case class C78(x: Int) extends Wide
+  object C78 { implicit val mongo: MongoFormat[C78] = deriveMongoFormat }
+  case class C79(x: Int) extends Wide
+  object C79 { implicit val mongo: MongoFormat[C79] = deriveMongoFormat }
+  case class C80(x: Int) extends Wide
+  object C80 { implicit val mongo: MongoFormat[C80] = deriveMongoFormat }
+  case class C81(x: Int) extends Wide
+  object C81 { implicit val mongo: MongoFormat[C81] = deriveMongoFormat }
+  case class C82(x: Int) extends Wide
+  object C82 { implicit val mongo: MongoFormat[C82] = deriveMongoFormat }
+  case class C83(x: Int) extends Wide
+  object C83 { implicit val mongo: MongoFormat[C83] = deriveMongoFormat }
+  case class C84(x: Int) extends Wide
+  object C84 { implicit val mongo: MongoFormat[C84] = deriveMongoFormat }
+  case class C85(x: Int) extends Wide
+  object C85 { implicit val mongo: MongoFormat[C85] = deriveMongoFormat }
+  case class C86(x: Int) extends Wide
+  object C86 { implicit val mongo: MongoFormat[C86] = deriveMongoFormat }
+  case class C87(x: Int) extends Wide
+  object C87 { implicit val mongo: MongoFormat[C87] = deriveMongoFormat }
+  case class C88(x: Int) extends Wide
+  object C88 { implicit val mongo: MongoFormat[C88] = deriveMongoFormat }
+  case class C89(x: Int) extends Wide
+  object C89 { implicit val mongo: MongoFormat[C89] = deriveMongoFormat }
+  case class C90(x: Int) extends Wide
+  object C90 { implicit val mongo: MongoFormat[C90] = deriveMongoFormat }
+  case class C91(x: Int) extends Wide
+  object C91 { implicit val mongo: MongoFormat[C91] = deriveMongoFormat }
+  case class C92(x: Int) extends Wide
+  object C92 { implicit val mongo: MongoFormat[C92] = deriveMongoFormat }
+  case class C93(x: Int) extends Wide
+  object C93 { implicit val mongo: MongoFormat[C93] = deriveMongoFormat }
+  case class C94(x: Int) extends Wide
+  object C94 { implicit val mongo: MongoFormat[C94] = deriveMongoFormat }
+  case class C95(x: Int) extends Wide
+  object C95 { implicit val mongo: MongoFormat[C95] = deriveMongoFormat }
+  case class C96(x: Int) extends Wide
+  object C96 { implicit val mongo: MongoFormat[C96] = deriveMongoFormat }
+  case class C97(x: Int) extends Wide
+  object C97 { implicit val mongo: MongoFormat[C97] = deriveMongoFormat }
+  case class C98(x: Int) extends Wide
+  object C98 { implicit val mongo: MongoFormat[C98] = deriveMongoFormat }
+  case class C99(x: Int) extends Wide
+  object C99 { implicit val mongo: MongoFormat[C99] = deriveMongoFormat }
+  case class C100(x: Int) extends Wide
+  object C100 { implicit val mongo: MongoFormat[C100] = deriveMongoFormat }
+  case class C101(x: Int) extends Wide
+  object C101 { implicit val mongo: MongoFormat[C101] = deriveMongoFormat }
+  case class C102(x: Int) extends Wide
+  object C102 { implicit val mongo: MongoFormat[C102] = deriveMongoFormat }
+  case class C103(x: Int) extends Wide
+  object C103 { implicit val mongo: MongoFormat[C103] = deriveMongoFormat }
+  case class C104(x: Int) extends Wide
+  object C104 { implicit val mongo: MongoFormat[C104] = deriveMongoFormat }
+  case class C105(x: Int) extends Wide
+  object C105 { implicit val mongo: MongoFormat[C105] = deriveMongoFormat }
+  case class C106(x: Int) extends Wide
+  object C106 { implicit val mongo: MongoFormat[C106] = deriveMongoFormat }
+  case class C107(x: Int) extends Wide
+  object C107 { implicit val mongo: MongoFormat[C107] = deriveMongoFormat }
+  case class C108(x: Int) extends Wide
+  object C108 { implicit val mongo: MongoFormat[C108] = deriveMongoFormat }
+  case class C109(x: Int) extends Wide
+  object C109 { implicit val mongo: MongoFormat[C109] = deriveMongoFormat }
+  case class C110(x: Int) extends Wide
+  object C110 { implicit val mongo: MongoFormat[C110] = deriveMongoFormat }
+  case class C111(x: Int) extends Wide
+  object C111 { implicit val mongo: MongoFormat[C111] = deriveMongoFormat }
+  case class C112(x: Int) extends Wide
+  object C112 { implicit val mongo: MongoFormat[C112] = deriveMongoFormat }
+  case class C113(x: Int) extends Wide
+  object C113 { implicit val mongo: MongoFormat[C113] = deriveMongoFormat }
+  case class C114(x: Int) extends Wide
+  object C114 { implicit val mongo: MongoFormat[C114] = deriveMongoFormat }
+  case class C115(x: Int) extends Wide
+  object C115 { implicit val mongo: MongoFormat[C115] = deriveMongoFormat }
+  case class C116(x: Int) extends Wide
+  object C116 { implicit val mongo: MongoFormat[C116] = deriveMongoFormat }
+  case class C117(x: Int) extends Wide
+  object C117 { implicit val mongo: MongoFormat[C117] = deriveMongoFormat }
+  case class C118(x: Int) extends Wide
+  object C118 { implicit val mongo: MongoFormat[C118] = deriveMongoFormat }
+  case class C119(x: Int) extends Wide
+  object C119 { implicit val mongo: MongoFormat[C119] = deriveMongoFormat }
+  case class C120(x: Int) extends Wide
+  object C120 { implicit val mongo: MongoFormat[C120] = deriveMongoFormat }
+  case class C121(x: Int) extends Wide
+  object C121 { implicit val mongo: MongoFormat[C121] = deriveMongoFormat }
+  case class C122(x: Int) extends Wide
+  object C122 { implicit val mongo: MongoFormat[C122] = deriveMongoFormat }
+  case class C123(x: Int) extends Wide
+  object C123 { implicit val mongo: MongoFormat[C123] = deriveMongoFormat }
+  case class C124(x: Int) extends Wide
+  object C124 { implicit val mongo: MongoFormat[C124] = deriveMongoFormat }
+  case class C125(x: Int) extends Wide
+  object C125 { implicit val mongo: MongoFormat[C125] = deriveMongoFormat }
+  case class C126(x: Int) extends Wide
+  object C126 { implicit val mongo: MongoFormat[C126] = deriveMongoFormat }
+  case class C127(x: Int) extends Wide
+  object C127 { implicit val mongo: MongoFormat[C127] = deriveMongoFormat }
+  case class C128(x: Int) extends Wide
+  object C128 { implicit val mongo: MongoFormat[C128] = deriveMongoFormat }
+  case class C129(x: Int) extends Wide
+  object C129 { implicit val mongo: MongoFormat[C129] = deriveMongoFormat }
+  case class C130(x: Int) extends Wide
+  object C130 { implicit val mongo: MongoFormat[C130] = deriveMongoFormat }
+  case class C131(x: Int) extends Wide
+  object C131 { implicit val mongo: MongoFormat[C131] = deriveMongoFormat }
+  case class C132(x: Int) extends Wide
+  object C132 { implicit val mongo: MongoFormat[C132] = deriveMongoFormat }
+  case class C133(x: Int) extends Wide
+  object C133 { implicit val mongo: MongoFormat[C133] = deriveMongoFormat }
+  case class C134(x: Int) extends Wide
+  object C134 { implicit val mongo: MongoFormat[C134] = deriveMongoFormat }
+  case class C135(x: Int) extends Wide
+  object C135 { implicit val mongo: MongoFormat[C135] = deriveMongoFormat }
+  case class C136(x: Int) extends Wide
+  object C136 { implicit val mongo: MongoFormat[C136] = deriveMongoFormat }
+  case class C137(x: Int) extends Wide
+  object C137 { implicit val mongo: MongoFormat[C137] = deriveMongoFormat }
+  case class C138(x: Int) extends Wide
+  object C138 { implicit val mongo: MongoFormat[C138] = deriveMongoFormat }
+  case class C139(x: Int) extends Wide
+  object C139 { implicit val mongo: MongoFormat[C139] = deriveMongoFormat }
+  case class C140(x: Int) extends Wide
+  object C140 { implicit val mongo: MongoFormat[C140] = deriveMongoFormat }
+  case class C141(x: Int) extends Wide
+  object C141 { implicit val mongo: MongoFormat[C141] = deriveMongoFormat }
+  case class C142(x: Int) extends Wide
+  object C142 { implicit val mongo: MongoFormat[C142] = deriveMongoFormat }
+  case class C143(x: Int) extends Wide
+  object C143 { implicit val mongo: MongoFormat[C143] = deriveMongoFormat }
+  case class C144(x: Int) extends Wide
+  object C144 { implicit val mongo: MongoFormat[C144] = deriveMongoFormat }
+  case class C145(x: Int) extends Wide
+  object C145 { implicit val mongo: MongoFormat[C145] = deriveMongoFormat }
+  case class C146(x: Int) extends Wide
+  object C146 { implicit val mongo: MongoFormat[C146] = deriveMongoFormat }
+  case class C147(x: Int) extends Wide
+  object C147 { implicit val mongo: MongoFormat[C147] = deriveMongoFormat }
+  case class C148(x: Int) extends Wide
+  object C148 { implicit val mongo: MongoFormat[C148] = deriveMongoFormat }
+  case class C149(x: Int) extends Wide
+  object C149 { implicit val mongo: MongoFormat[C149] = deriveMongoFormat }
+  case class C150(x: Int) extends Wide
+  object C150 { implicit val mongo: MongoFormat[C150] = deriveMongoFormat }
+  case class C151(x: Int) extends Wide
+  object C151 { implicit val mongo: MongoFormat[C151] = deriveMongoFormat }
+  case class C152(x: Int) extends Wide
+  object C152 { implicit val mongo: MongoFormat[C152] = deriveMongoFormat }
+  case class C153(x: Int) extends Wide
+  object C153 { implicit val mongo: MongoFormat[C153] = deriveMongoFormat }
+  case class C154(x: Int) extends Wide
+  object C154 { implicit val mongo: MongoFormat[C154] = deriveMongoFormat }
+  case class C155(x: Int) extends Wide
+  object C155 { implicit val mongo: MongoFormat[C155] = deriveMongoFormat }
+  case class C156(x: Int) extends Wide
+  object C156 { implicit val mongo: MongoFormat[C156] = deriveMongoFormat }
+  case class C157(x: Int) extends Wide
+  object C157 { implicit val mongo: MongoFormat[C157] = deriveMongoFormat }
+  case class C158(x: Int) extends Wide
+  object C158 { implicit val mongo: MongoFormat[C158] = deriveMongoFormat }
+  case class C159(x: Int) extends Wide
+  object C159 { implicit val mongo: MongoFormat[C159] = deriveMongoFormat }
+  case class C160(x: Int) extends Wide
+  object C160 { implicit val mongo: MongoFormat[C160] = deriveMongoFormat }
+  case class C161(x: Int) extends Wide
+  object C161 { implicit val mongo: MongoFormat[C161] = deriveMongoFormat }
+  case class C162(x: Int) extends Wide
+  object C162 { implicit val mongo: MongoFormat[C162] = deriveMongoFormat }
+  case class C163(x: Int) extends Wide
+  object C163 { implicit val mongo: MongoFormat[C163] = deriveMongoFormat }
+  case class C164(x: Int) extends Wide
+  object C164 { implicit val mongo: MongoFormat[C164] = deriveMongoFormat }
+  case class C165(x: Int) extends Wide
+  object C165 { implicit val mongo: MongoFormat[C165] = deriveMongoFormat }
+  case class C166(x: Int) extends Wide
+  object C166 { implicit val mongo: MongoFormat[C166] = deriveMongoFormat }
+  case class C167(x: Int) extends Wide
+  object C167 { implicit val mongo: MongoFormat[C167] = deriveMongoFormat }
+  case class C168(x: Int) extends Wide
+  object C168 { implicit val mongo: MongoFormat[C168] = deriveMongoFormat }
+  case class C169(x: Int) extends Wide
+  object C169 { implicit val mongo: MongoFormat[C169] = deriveMongoFormat }
+  case class C170(x: Int) extends Wide
+  object C170 { implicit val mongo: MongoFormat[C170] = deriveMongoFormat }
+  case class C171(x: Int) extends Wide
+  object C171 { implicit val mongo: MongoFormat[C171] = deriveMongoFormat }
+  case class C172(x: Int) extends Wide
+  object C172 { implicit val mongo: MongoFormat[C172] = deriveMongoFormat }
+  case class C173(x: Int) extends Wide
+  object C173 { implicit val mongo: MongoFormat[C173] = deriveMongoFormat }
+  case class C174(x: Int) extends Wide
+  object C174 { implicit val mongo: MongoFormat[C174] = deriveMongoFormat }
+  case class C175(x: Int) extends Wide
+  object C175 { implicit val mongo: MongoFormat[C175] = deriveMongoFormat }
+  case class C176(x: Int) extends Wide
+  object C176 { implicit val mongo: MongoFormat[C176] = deriveMongoFormat }
+  case class C177(x: Int) extends Wide
+  object C177 { implicit val mongo: MongoFormat[C177] = deriveMongoFormat }
+  case class C178(x: Int) extends Wide
+  object C178 { implicit val mongo: MongoFormat[C178] = deriveMongoFormat }
+  case class C179(x: Int) extends Wide
+  object C179 { implicit val mongo: MongoFormat[C179] = deriveMongoFormat }
+  case class C180(x: Int) extends Wide
+  object C180 { implicit val mongo: MongoFormat[C180] = deriveMongoFormat }
+  case class C181(x: Int) extends Wide
+  object C181 { implicit val mongo: MongoFormat[C181] = deriveMongoFormat }
+  case class C182(x: Int) extends Wide
+  object C182 { implicit val mongo: MongoFormat[C182] = deriveMongoFormat }
+  case class C183(x: Int) extends Wide
+  object C183 { implicit val mongo: MongoFormat[C183] = deriveMongoFormat }
+  case class C184(x: Int) extends Wide
+  object C184 { implicit val mongo: MongoFormat[C184] = deriveMongoFormat }
+  case class C185(x: Int) extends Wide
+  object C185 { implicit val mongo: MongoFormat[C185] = deriveMongoFormat }
+  case class C186(x: Int) extends Wide
+  object C186 { implicit val mongo: MongoFormat[C186] = deriveMongoFormat }
+  case class C187(x: Int) extends Wide
+  object C187 { implicit val mongo: MongoFormat[C187] = deriveMongoFormat }
+  case class C188(x: Int) extends Wide
+  object C188 { implicit val mongo: MongoFormat[C188] = deriveMongoFormat }
+  case class C189(x: Int) extends Wide
+  object C189 { implicit val mongo: MongoFormat[C189] = deriveMongoFormat }
+  case class C190(x: Int) extends Wide
+  object C190 { implicit val mongo: MongoFormat[C190] = deriveMongoFormat }
+  case class C191(x: Int) extends Wide
+  object C191 { implicit val mongo: MongoFormat[C191] = deriveMongoFormat }
+  case class C192(x: Int) extends Wide
+  object C192 { implicit val mongo: MongoFormat[C192] = deriveMongoFormat }
+  case class C193(x: Int) extends Wide
+  object C193 { implicit val mongo: MongoFormat[C193] = deriveMongoFormat }
+  case class C194(x: Int) extends Wide
+  object C194 { implicit val mongo: MongoFormat[C194] = deriveMongoFormat }
+  case class C195(x: Int) extends Wide
+  object C195 { implicit val mongo: MongoFormat[C195] = deriveMongoFormat }
+  case class C196(x: Int) extends Wide
+  object C196 { implicit val mongo: MongoFormat[C196] = deriveMongoFormat }
+  case class C197(x: Int) extends Wide
+  object C197 { implicit val mongo: MongoFormat[C197] = deriveMongoFormat }
+  case class C198(x: Int) extends Wide
+  object C198 { implicit val mongo: MongoFormat[C198] = deriveMongoFormat }
+  case class C199(x: Int) extends Wide
+  object C199 { implicit val mongo: MongoFormat[C199] = deriveMongoFormat }
+  case class C200(x: Int) extends Wide
+  object C200 { implicit val mongo: MongoFormat[C200] = deriveMongoFormat }
+  // format: on
+
+  val mongo: MongoFormat[Wide] = mongoTypeSwitch[Wide](
+    List(
+      sub[C1],
+      sub[C2],
+      sub[C3],
+      sub[C4],
+      sub[C5],
+      sub[C6],
+      sub[C7],
+      sub[C8],
+      sub[C9],
+      sub[C10],
+      sub[C11],
+      sub[C12],
+      sub[C13],
+      sub[C14],
+      sub[C15],
+      sub[C16],
+      sub[C17],
+      sub[C18],
+      sub[C19],
+      sub[C20],
+      sub[C21],
+      sub[C22],
+      sub[C23],
+      sub[C24],
+      sub[C25],
+      sub[C26],
+      sub[C27],
+      sub[C28],
+      sub[C29],
+      sub[C30],
+      sub[C31],
+      sub[C32],
+      sub[C33],
+      sub[C34],
+      sub[C35],
+      sub[C36],
+      sub[C37],
+      sub[C38],
+      sub[C39],
+      sub[C40],
+      sub[C41],
+      sub[C42],
+      sub[C43],
+      sub[C44],
+      sub[C45],
+      sub[C46],
+      sub[C47],
+      sub[C48],
+      sub[C49],
+      sub[C50],
+      sub[C51],
+      sub[C52],
+      sub[C53],
+      sub[C54],
+      sub[C55],
+      sub[C56],
+      sub[C57],
+      sub[C58],
+      sub[C59],
+      sub[C60],
+      sub[C61],
+      sub[C62],
+      sub[C63],
+      sub[C64],
+      sub[C65],
+      sub[C66],
+      sub[C67],
+      sub[C68],
+      sub[C69],
+      sub[C70],
+      sub[C71],
+      sub[C72],
+      sub[C73],
+      sub[C74],
+      sub[C75],
+      sub[C76],
+      sub[C77],
+      sub[C78],
+      sub[C79],
+      sub[C80],
+      sub[C81],
+      sub[C82],
+      sub[C83],
+      sub[C84],
+      sub[C85],
+      sub[C86],
+      sub[C87],
+      sub[C88],
+      sub[C89],
+      sub[C90],
+      sub[C91],
+      sub[C92],
+      sub[C93],
+      sub[C94],
+      sub[C95],
+      sub[C96],
+      sub[C97],
+      sub[C98],
+      sub[C99],
+      sub[C100],
+      sub[C101],
+      sub[C102],
+      sub[C103],
+      sub[C104],
+      sub[C105],
+      sub[C106],
+      sub[C107],
+      sub[C108],
+      sub[C109],
+      sub[C110],
+      sub[C111],
+      sub[C112],
+      sub[C113],
+      sub[C114],
+      sub[C115],
+      sub[C116],
+      sub[C117],
+      sub[C118],
+      sub[C119],
+      sub[C120],
+      sub[C121],
+      sub[C122],
+      sub[C123],
+      sub[C124],
+      sub[C125],
+      sub[C126],
+      sub[C127],
+      sub[C128],
+      sub[C129],
+      sub[C130],
+      sub[C131],
+      sub[C132],
+      sub[C133],
+      sub[C134],
+      sub[C135],
+      sub[C136],
+      sub[C137],
+      sub[C138],
+      sub[C139],
+      sub[C140],
+      sub[C141],
+      sub[C142],
+      sub[C143],
+      sub[C144],
+      sub[C145],
+      sub[C146],
+      sub[C147],
+      sub[C148],
+      sub[C149],
+      sub[C150],
+      sub[C151],
+      sub[C152],
+      sub[C153],
+      sub[C154],
+      sub[C155],
+      sub[C156],
+      sub[C157],
+      sub[C158],
+      sub[C159],
+      sub[C160],
+      sub[C161],
+      sub[C162],
+      sub[C163],
+      sub[C164],
+      sub[C165],
+      sub[C166],
+      sub[C167],
+      sub[C168],
+      sub[C169],
+      sub[C170],
+      sub[C171],
+      sub[C172],
+      sub[C173],
+      sub[C174],
+      sub[C175],
+      sub[C176],
+      sub[C177],
+      sub[C178],
+      sub[C179],
+      sub[C180],
+      sub[C181],
+      sub[C182],
+      sub[C183],
+      sub[C184],
+      sub[C185],
+      sub[C186],
+      sub[C187],
+      sub[C188],
+      sub[C189],
+      sub[C190],
+      sub[C191],
+      sub[C192],
+      sub[C193],
+      sub[C194],
+      sub[C195],
+      sub[C196],
+      sub[C197],
+      sub[C198],
+      sub[C199],
+      sub[C200]
+    ))
+
+  val derived: MongoFormat[Wide] = deriveMongoFormat[Wide]
+
+  val values: List[Wide] = List(
+    C1(1),
+    C2(2),
+    C3(3),
+    C4(4),
+    C5(5),
+    C6(6),
+    C7(7),
+    C8(8),
+    C9(9),
+    C10(10),
+    C11(11),
+    C12(12),
+    C13(13),
+    C14(14),
+    C15(15),
+    C16(16),
+    C17(17),
+    C18(18),
+    C19(19),
+    C20(20),
+    C21(21),
+    C22(22),
+    C23(23),
+    C24(24),
+    C25(25),
+    C26(26),
+    C27(27),
+    C28(28),
+    C29(29),
+    C30(30),
+    C31(31),
+    C32(32),
+    C33(33),
+    C34(34),
+    C35(35),
+    C36(36),
+    C37(37),
+    C38(38),
+    C39(39),
+    C40(40),
+    C41(41),
+    C42(42),
+    C43(43),
+    C44(44),
+    C45(45),
+    C46(46),
+    C47(47),
+    C48(48),
+    C49(49),
+    C50(50),
+    C51(51),
+    C52(52),
+    C53(53),
+    C54(54),
+    C55(55),
+    C56(56),
+    C57(57),
+    C58(58),
+    C59(59),
+    C60(60),
+    C61(61),
+    C62(62),
+    C63(63),
+    C64(64),
+    C65(65),
+    C66(66),
+    C67(67),
+    C68(68),
+    C69(69),
+    C70(70),
+    C71(71),
+    C72(72),
+    C73(73),
+    C74(74),
+    C75(75),
+    C76(76),
+    C77(77),
+    C78(78),
+    C79(79),
+    C80(80),
+    C81(81),
+    C82(82),
+    C83(83),
+    C84(84),
+    C85(85),
+    C86(86),
+    C87(87),
+    C88(88),
+    C89(89),
+    C90(90),
+    C91(91),
+    C92(92),
+    C93(93),
+    C94(94),
+    C95(95),
+    C96(96),
+    C97(97),
+    C98(98),
+    C99(99),
+    C100(100),
+    C101(101),
+    C102(102),
+    C103(103),
+    C104(104),
+    C105(105),
+    C106(106),
+    C107(107),
+    C108(108),
+    C109(109),
+    C110(110),
+    C111(111),
+    C112(112),
+    C113(113),
+    C114(114),
+    C115(115),
+    C116(116),
+    C117(117),
+    C118(118),
+    C119(119),
+    C120(120),
+    C121(121),
+    C122(122),
+    C123(123),
+    C124(124),
+    C125(125),
+    C126(126),
+    C127(127),
+    C128(128),
+    C129(129),
+    C130(130),
+    C131(131),
+    C132(132),
+    C133(133),
+    C134(134),
+    C135(135),
+    C136(136),
+    C137(137),
+    C138(138),
+    C139(139),
+    C140(140),
+    C141(141),
+    C142(142),
+    C143(143),
+    C144(144),
+    C145(145),
+    C146(146),
+    C147(147),
+    C148(148),
+    C149(149),
+    C150(150),
+    C151(151),
+    C152(152),
+    C153(153),
+    C154(154),
+    C155(155),
+    C156(156),
+    C157(157),
+    C158(158),
+    C159(159),
+    C160(160),
+    C161(161),
+    C162(162),
+    C163(163),
+    C164(164),
+    C165(165),
+    C166(166),
+    C167(167),
+    C168(168),
+    C169(169),
+    C170(170),
+    C171(171),
+    C172(172),
+    C173(173),
+    C174(174),
+    C175(175),
+    C176(176),
+    C177(177),
+    C178(178),
+    C179(179),
+    C180(180),
+    C181(181),
+    C182(182),
+    C183(183),
+    C184(184),
+    C185(185),
+    C186(186),
+    C187(187),
+    C188(188),
+    C189(189),
+    C190(190),
+    C191(191),
+    C192(192),
+    C193(193),
+    C194(194),
+    C195(195),
+    C196(196),
+    C197(197),
+    C198(198),
+    C199(199),
+    C200(200)
+  )
+}

--- a/util/src/main/scala/Reflect.scala
+++ b/util/src/main/scala/Reflect.scala
@@ -20,6 +20,11 @@ object Reflect extends Logging {
     CaseClassMeta(getCaseClassFieldMeta(clazz))
   })
 
+  /** For a class nested in an object it is the *enclosing* signature that gets parsed, the same one
+    * for every sibling — so without this memo N siblings cost N full parses.
+    */
+  private val parseScalaSig = new Memoizer[Class[_], Option[ScalaSig]](ScalaSigParser.parse)
+
   private def getCompanionClass(clazz: Class[_]): Class[_] =
     Class.forName(clazz.getName + "$", true, clazz.getClassLoader)
   private def getCompanionObject(companionClass: Class[_]): Object =
@@ -31,10 +36,10 @@ object Reflect extends Logging {
       val companionObject = getCompanionObject(companionClass)
 
       val maybeSym = clazz.getName.split("\\$") match {
-        case Array(_) => ScalaSigParser.parse(clazz).flatMap(_.topLevelClasses.headOption)
+        case Array(_) => parseScalaSig(clazz).flatMap(_.topLevelClasses.headOption)
         case Array(h, t @ _*) =>
           val name = t.last
-          val topSymbol = ScalaSigParser.parse(Class.forName(h, true, clazz.getClassLoader))
+          val topSymbol = parseScalaSig(Class.forName(h, true, clazz.getClassLoader))
           topSymbol.flatMap(_.symbols.collectFirst { case s: ClassSymbol if s.name == name => s })
       }
 


### PR DESCRIPTION
PR description (branch Port-type-switch-syntax, 2 commits):

### Note 

Most of the diff is the 200 element long testing:
- There are 2 files named WideTypeSwitchSpec.scala both are 840 lines. So that alone takes up +1700 lines, but these 2 files are easy to review.  


## Common type-switch syntax for Scala 2 and 3

Scala 2's `jsonTypeSwitch` took subtypes as a type-parameter list plus a `List` tail;
Scala 3 takes them as a value-level list. This ports Scala 2 to the Scala 3 shape so
the call site is identical on both, and drops the fmpp-generated arity overloads.


```scala
// before (Scala 2 only)
jsonTypeSwitch[Message, TypeA, TypeB](Nil)
toJsonTypeSwitch[Message, TypeA, TypeB](Nil)
mongoTypeSwitch[Message, TypeA, TypeB](Nil)

// after (both versions)
jsonTypeSwitch[Message](List(sub[TypeA], sub[TypeB]))
toJsonTypeSwitch[Message](List(subTo[TypeA], subTo[TypeB]))
mongoTypeSwitch[Message](List(sub[TypeA], sub[TypeB]))
```

### Why

- This syntax will work exactly the same with scala3 as well, the tests can be as close as possible. 
- Lifts the ~125-subtype ceiling that came from the JVM 255-parameter limit —
  verified at 200 subtypes on both sides (WideTypeSwitchSpec).
  - This will allow us to remove some workaround cases with both `jsonTypeSwitch` and `mongoTypeSwitch` 
  
#### Bonus
- Removes ~750 fmpp-generated overloads (arities 3..126) across jsonTypeSwitch,
  toJsonTypeSwitch, fromJsonTypeSwitch, jsonSingletonEnumSwitch, mongoTypeSwitch.

### Some changes

Follow-up commit removes `TypeSelectorBase.typeField`, which became unused: it was
write-side only and is unrepresentable on the read side.

### Breaking

 The call sites will need to be ported, but there's only about 20-30 method calls. (I actually have a branch, all green, I can show it) 


